### PR TITLE
Change from Callback to Task based - IdsAvailable

### DIFF
--- a/Com.OneSignal.Abstractions/Com.OneSignal.Abstractions.csproj
+++ b/Com.OneSignal.Abstractions/Com.OneSignal.Abstractions.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -27,6 +27,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="IdsResult.cs" />
     <Compile Include="OneSignalShared.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="OSNotificationPayload.cs" />

--- a/Com.OneSignal.Abstractions/IOneSignal.cs
+++ b/Com.OneSignal.Abstractions/IOneSignal.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Com.OneSignal.Abstractions
 {
@@ -14,7 +15,9 @@ namespace Com.OneSignal.Abstractions
       void GetTags(TagsReceived tagsReceivedDelegate);
       void DeleteTag(string key);
       void DeleteTags(IList<string> keys);
+      [Obsolete]
       void IdsAvailable(IdsAvailableCallback idsAvailableCallback);
+      Task<IdsResult> IdsAvailableAsync();
       void SetSubscription(bool enable);
       void PostNotification(Dictionary<string, object> data);
       void SyncHashedEmail(string email);

--- a/Com.OneSignal.Abstractions/IdsResult.cs
+++ b/Com.OneSignal.Abstractions/IdsResult.cs
@@ -1,0 +1,8 @@
+﻿namespace Com.OneSignal.Abstractions
+{
+    public class IdsResult
+    {
+        public string PlayerId { get; set; }
+        public string PushToken { get; set; }
+    }
+}

--- a/Com.OneSignal.Android/Com.OneSignal.Android.csproj
+++ b/Com.OneSignal.Android/Com.OneSignal.Android.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,11 +8,12 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Com.OneSignal</RootNamespace>
     <AssemblyName>Com.OneSignal</AssemblyName>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <AndroidTlsProvider></AndroidTlsProvider>
+    <AndroidTlsProvider>
+    </AndroidTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Android.App;
 using Com.OneSignal.Abstractions;
 
@@ -58,6 +60,24 @@ namespace Com.OneSignal
         public override void IdsAvailable()
         {
             Android.OneSignal.IdsAvailable(new IdsAvailableHandler());
+        }
+
+        public Task<IdsResult> IdsAvailableAsync()
+        {
+            var taskCompletionSource = new TaskCompletionSource<IdsResult>();
+
+            Action<string, string> action = (id, push) =>
+            {
+                var result = new IdsResult()
+                {
+                    PlayerId = id, PushToken = push
+                };
+                taskCompletionSource.SetResult(result);
+            };
+
+            Android.OneSignal.IdsAvailable(new IdsAvailableCallback(action));
+
+            return taskCompletionSource.Task;
         }
 
         public override void RegisterForPushNotifications() { } // Doesn't apply to Android as the Native SDK always registers with GCM.

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Com.OneSignal.Abstractions;
 using OSNotificationOpenedResult = Com.OneSignal.Abstractions.OSNotificationOpenedResult;
 using OSNotification = Com.OneSignal.Abstractions.OSNotification;
@@ -148,6 +149,7 @@ namespace Com.OneSignal
          iOS.OneSignal.IdsAvailable(IdsAvailableHandler);
       }
 
+
       public override void SetSubscription(bool enable)
       {
          iOS.OneSignal.SetSubscription(enable);
@@ -173,7 +175,26 @@ namespace Com.OneSignal
          onIdsAvailable(playerID, pushToken);
       }
 
-      public void NotificationOpenedHandler(iOS.OSNotificationOpenedResult result)
+       public Task<IdsResult> IdsAvailableAsync()
+       {
+           var taskCompletionSource = new TaskCompletionSource<IdsResult>();
+
+           Action<string, string> action = (id, push) =>
+           {
+               var result = new IdsResult()
+               {
+                   PlayerId = id,
+                   PushToken = push
+               };
+               taskCompletionSource.SetResult(result);
+           };
+
+           iOS.OneSignal.IdsAvailable(new IdsAvailableCallback(action));
+
+           return taskCompletionSource.Task;
+       }
+
+        public void NotificationOpenedHandler(iOS.OSNotificationOpenedResult result)
       {
          onPushNotificationOpened(OSNotificationOpenedResultToNative(result));
       }

--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,8 +11,9 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>OneSignal.Android.Binding</AssemblyName>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
-    <AndroidTlsProvider></AndroidTlsProvider>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <AndroidTlsProvider>
+    </AndroidTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
+++ b/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -34,7 +34,8 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -51,7 +52,8 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
@@ -90,8 +92,12 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\Contents.json">
+      <InProject>false</InProject>
+    </ImageAsset>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />


### PR DESCRIPTION
We can use IdsAvailable as a Task in order to get a much more readable code.

```
var result = await OneSignal.Current.IdsAvailableAsync();
//result.PlayerId
//result.PushToken
```