### PR TITLE
Add ClearOneSignalNotifications()

### DIFF
--- a/Com.OneSignal.Abstractions/IOneSignal.cs
+++ b/Com.OneSignal.Abstractions/IOneSignal.cs
@@ -28,7 +28,7 @@ namespace Com.OneSignal.Abstractions
       void SetEmail(string email);
       void LogoutEmail(OnSetEmailSuccess success, OnSetEmailFailure failure);
       void LogoutEmail();
-      void ClearOneSignalNotifications();
+      void ClearAndroidOneSignalNotifications();
    }
 }
  

--- a/Com.OneSignal.Abstractions/IOneSignal.cs
+++ b/Com.OneSignal.Abstractions/IOneSignal.cs
@@ -28,6 +28,7 @@ namespace Com.OneSignal.Abstractions
       void SetEmail(string email);
       void LogoutEmail(OnSetEmailSuccess success, OnSetEmailFailure failure);
       void LogoutEmail();
+      void ClearOneSignalNotifications();
    }
 }
  

--- a/Com.OneSignal.Abstractions/OneSignalShared.cs
+++ b/Com.OneSignal.Abstractions/OneSignalShared.cs
@@ -34,7 +34,7 @@ namespace Com.OneSignal.Abstractions
       public abstract void SetSubscription(bool enable);
       public abstract void PromptLocation();
 
-      public abstract void ClearOneSignalNotifications();
+      public abstract void ClearAndroidOneSignalNotifications();
 
       [Obsolete("SyncHashedEmail has been deprecated. Please use SetEmail() instead.")]
       public abstract void SyncHashedEmail(string email);

--- a/Com.OneSignal.Abstractions/OneSignalShared.cs
+++ b/Com.OneSignal.Abstractions/OneSignalShared.cs
@@ -34,6 +34,8 @@ namespace Com.OneSignal.Abstractions
       public abstract void SetSubscription(bool enable);
       public abstract void PromptLocation();
 
+      public abstract void ClearOneSignalNotifications();
+
       [Obsolete("SyncHashedEmail has been deprecated. Please use SetEmail() instead.")]
       public abstract void SyncHashedEmail(string email);
 

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Android.App;
 using System;
+using System.Diagnostics;
 using Com.OneSignal.Abstractions;
 
 namespace Com.OneSignal
@@ -99,7 +100,7 @@ namespace Com.OneSignal
             Android.OneSignal.PromptLocation();
         }
 
-        public void ClearOneSignalNotifications()
+        public override void ClearOneSignalNotifications()
         {
             Android.OneSignal.ClearOneSignalNotifications();
         }

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Android.App;
 using System;
-using System.Diagnostics;
 using Com.OneSignal.Abstractions;
 
 namespace Com.OneSignal
@@ -100,7 +99,7 @@ namespace Com.OneSignal
             Android.OneSignal.PromptLocation();
         }
 
-        public override void ClearOneSignalNotifications()
+        public override void ClearAndroidOneSignalNotifications()
         {
             Android.OneSignal.ClearOneSignalNotifications();
         }

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -145,9 +145,9 @@ namespace Com.OneSignal
       iOS.OneSignal.DeleteTags(objs);
     }
 
-    public override void ClearOneSignalNotifications()
+    public override void ClearAndroidOneSignalNotifications()
     {
-       throw new NotImplementedException();
+         Debug.WriteLine("ClearAndroidOneSignalNotifications() is an android-only function, and is not implemented in iOS.");
     }
       
     public override void IdsAvailable()

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -145,6 +145,11 @@ namespace Com.OneSignal
       iOS.OneSignal.DeleteTags(objs);
     }
 
+    public override void ClearOneSignalNotifications()
+    {
+       throw new NotImplementedException();
+    }
+      
     public override void IdsAvailable()
     {
       iOS.OneSignal.IdsAvailable(IdsAvailableHandler);


### PR DESCRIPTION
• Exposes the ClearOneSignalNotifications() function to Android xamarin
• If called from iOS it will throw a Not Implemented exception