### PR TITLE
Version release commit 3.4.0

### DIFF
--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.OneSignal</id>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <title>OneSignal SDK for Xamarin</title>
         <authors>OneSignal, Martijn van Dijk</authors>
         <owners>OneSignal</owners>
@@ -18,7 +18,8 @@
                 <dependency id="Xamarin.Android.Support.v4" version="26.0.2" />
                 <dependency id="Xamarin.Android.Support.v7.CardView" version="26.0.2" />
                 <dependency id="Xamarin.Android.Support.CustomTabs" version="26.0.2" />
-                <dependency id="Xamarin.Firebase.Messaging" version="42.1021.1" />
+                <dependency id="Xamarin.GooglePlayServices.Ads.Identifier" version="71.1600.0" />
+                <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
             </group>
             <group targetFramework="netstandard1.0">
                 <dependency id="NETStandard.Library" version="1.6.1" />

--- a/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
+++ b/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
@@ -165,6 +165,9 @@
     <Reference Include="Xamarin.Firebase.Messaging">
       <HintPath>..\..\packages\Xamarin.Firebase.Messaging.71.1740.0\lib\monoandroid90\Xamarin.Firebase.Messaging.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Ads.Identifier">
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Ads.Identifier.71.1600.0\lib\monoandroid90\Xamarin.GooglePlayServices.Ads.Identifier.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -244,4 +247,5 @@
   <Import Project="..\..\packages\Xamarin.Firebase.Iid.Interop.71.1601.0\build\MonoAndroid90\Xamarin.Firebase.Iid.Interop.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Iid.Interop.71.1601.0\build\MonoAndroid90\Xamarin.Firebase.Iid.Interop.targets')" />
   <Import Project="..\..\packages\Xamarin.Firebase.Iid.71.1710.0\build\MonoAndroid90\Xamarin.Firebase.Iid.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Iid.71.1710.0\build\MonoAndroid90\Xamarin.Firebase.Iid.targets')" />
   <Import Project="..\..\packages\Xamarin.Firebase.Messaging.71.1740.0\build\MonoAndroid90\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Messaging.71.1740.0\build\MonoAndroid90\Xamarin.Firebase.Messaging.targets')" />
+  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Ads.Identifier.71.1600.0\build\MonoAndroid90\Xamarin.GooglePlayServices.Ads.Identifier.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Ads.Identifier.71.1600.0\build\MonoAndroid90\Xamarin.GooglePlayServices.Ads.Identifier.targets')" />
 </Project>

--- a/Samples/Com.OneSignal.Sample.Droid/packages.config
+++ b/Samples/Com.OneSignal.Sample.Droid/packages.config
@@ -37,6 +37,7 @@
   <package id="Xamarin.Firebase.Measurement.Connector" version="71.1701.0" targetFramework="monoandroid90" />
   <package id="Xamarin.Firebase.Messaging" version="71.1740.0" targetFramework="monoandroid90" />
   <package id="Xamarin.Google.AutoValue.Annotations" version="1.6.5" targetFramework="monoandroid90" />
+  <package id="Xamarin.GooglePlayServices.Ads.Identifier" version="71.1600.0" targetFramework="monoandroid90" />
   <package id="Xamarin.GooglePlayServices.Base" version="71.1610.0" targetFramework="monoandroid90" />
   <package id="Xamarin.GooglePlayServices.Basement" version="71.1620.0" targetFramework="monoandroid90" />
   <package id="Xamarin.GooglePlayServices.Stats" version="71.1601.0" targetFramework="monoandroid90" />


### PR DESCRIPTION
* Added `Xamarin.GooglePlayServices.Ads.Identifier` to fix missing `AdvertisingIdClient` when upgrading to version `70+` of `Xamarin.GooglePlayServices.Basement`.
   - Upgraded `Xamarin.Firebase.Messaging` to `71.1740.0` to follow this upgrade.