### PR TITLE
Update Android Support Dependencies to 28 and Add Xamarin.AndroidX.Migration 

### DIFF
--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -18,6 +18,8 @@
                 <dependency id="Xamarin.Android.Support.v4" version="28.0.0.3" />
                 <dependency id="Xamarin.Android.Support.v7.CardView" version="28.0.0.3" />
                 <dependency id="Xamarin.Android.Support.CustomTabs" version="28.0.0.3" />
+                <!-- This does the same thing as Google's Jetifier -->
+                <dependency id="Xamarin.AndroidX.Migration" version="1.0.8" />
                 <dependency id="Xamarin.GooglePlayServices.Ads.Identifier" version="71.1600.0" />
                 <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
             </group>

--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -15,9 +15,9 @@
         <tags>xamarin, monodroid, C#, OneSignal, push</tags>
         <dependencies>
             <group targetFramework="MonoAndroid">
-                <dependency id="Xamarin.Android.Support.v4" version="26.0.2" />
-                <dependency id="Xamarin.Android.Support.v7.CardView" version="26.0.2" />
-                <dependency id="Xamarin.Android.Support.CustomTabs" version="26.0.2" />
+                <dependency id="Xamarin.Android.Support.v4" version="28.0.0.3" />
+                <dependency id="Xamarin.Android.Support.v7.CardView" version="28.0.0.3" />
+                <dependency id="Xamarin.Android.Support.CustomTabs" version="28.0.0.3" />
                 <dependency id="Xamarin.GooglePlayServices.Ads.Identifier" version="71.1600.0" />
                 <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
             </group>


### PR DESCRIPTION
## Issue
`Xamarin.AndroidX.Migration` requires that all Android Support Library references be the latest Android Support Library version 28 otherwise it won't apply.

## Fix
* Updated all `Xamarin.Android.Support.*` references to the latest `28.0.0.3` version.
* Added `Xamarin.AndroidX.Migration` as a dependency since Google Play requires apps to target 29

## Resolves
* This should resolve #219 & resolve #225 & resolve #230

## Tested
Example where upgrading Android Support Dependencies to 28 and adding Xamarin.AndroidX.Migration worked correctly:
https://github.com/jkasten2/Xamarin-AndroidAPI30-OneSignal3.10.4

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/232)
<!-- Reviewable:end -->

