### PR TITLE
Fix missing FCM dependency, missing Dagger 

### DIFF
--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -24,6 +24,9 @@
                 <dependency id="Xamarin.AndroidX.Work.Runtime" version="2.7.0" />
 
                 <dependency id="Xamarin.Firebase.Messaging" version="122.0.0.2" />
+                <!-- Dagger is required for FCM, should be a "transitive dependency" but is not due to this bug:
+                     https://github.com/xamarin/XamarinComponents/issues/1069 -->
+                <dependency id="Xamarin.Google.Dagger" version="2.39.1" />
             </group>
             <group targetFramework="netstandard2.0">
                 <dependency id="NETStandard.Library" version="2.0" />


### PR DESCRIPTION
## Description
Dagger is required for FCM, it should be a "transitive dependency" but due to a bug we are adding it manually as a top level dependency to work around the Xamarin bug:
- https://github.com/xamarin/XamarinComponents/issues/1069

## What this fixes
This fixes the following error at runtime when the Android device tries to get an FCM token.
```
[FirebaseApp] Device unlocked: initializing all Firebase APIs for app ONESIGNAL_SDK_FCM_APP_NAME
[art] Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.dagger.internal.Factory>
[art] Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.dagger.internal.Factory>
[art] Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.ExecutionModule_ExecutorFactory>
[art] Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.ExecutionModule_ExecutorFactory>
[art] Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.dagger.internal.DoubleCheck>
[art] Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.dagger.internal.DoubleCheck>
[OneSignal] 	at com.google.firebase.component11-17 18:12:57.750 I/art     ( 9810): Rejecting re-init on previously-failed class java.lang.Class<com.google.android.datatransport.runtime.ExecutionModule_ExecutorFactory>
[OneSignal] Unknown error getting FCM Token
[OneSignal] java.lang.NoClassDefFoundError: com.google.android.datatransport.runtime.ExecutionModule_ExecutorFactory
[OneSignal] 	at com.google.android.datatransport.runtime.DaggerTransportRuntimeComponent.initialize(DaggerTransportRuntimeComponent.java:75)
[OneSignal] 	at com.google.android.datatransport.runtime.DaggerTransportRuntimeComponent.<init>(DaggerTransportRuntimeComponent.java:66)
[OneSignal] 	at com.google.firTransportRuntimeComponent.java:36)
[OneSignal] 	at com.google.android.datatransport.runtime.DaggerTransportRuntimeComponent$Builder.build(DaggerTransportRuntimeComponent.java:109)
[OneSignal] 	at com.google.android.datatransport.runtime.TransportRuntime.initialize(TransportRuntime.java:78)
[OneSignal] 	at com.google.firebase.datatransport.TransportRegistrar.lambda$getComponents$0(TransportRegistrar.java:37)
[OneSignal] 	at com.google.firebase.datatransport.-$$Lambda$TransportRegistrar$cPZPPfWZLxVwhtSgzJNU9TpSidE.create(lambda)
[OneSignal] 	at com.google.firebase.components.ComponentRuntime.lambda$discoverComponents$0$ComponentRuntime(ComponentRuntime.java:132)
[OneSignal] 	at com.google.firebase.components.-$$Lambda$ComponentRuntime$4FqOW9eOQsvFYo-HpMfxCOnPQr0.get(lambda)
[OneSignal] 	at com.google.firebase.components.AbstractComponentContainer.get(AbstractComponentContainer.java:27)
[OneSignal] 	at com.google.firebase.components.ComponentRuntime.get(ComponentRuntime.java:45)
[OneSignal] 	at com.google.firebase.components.RestrictedComponentContainer.get(RestrictedComponentContainer.java:89)
[OneSignal] 	at com.google.firebase.messaging.FirebaseMessagingRegistrar.lambda$getComponents$0$FirebaseMessagingRegistrar(com.google.firebase:firebase-messaging@@22.0.0:7)
[OneSignal] 	at com.google.firebase.messaging.FirebaseMessagingRegistrar$$Lambda$0.create(com.google.firebase:firebase-messaging@@22.0.0)
[OneSignal] 	at com.google.firebase.components.ComponentRuntime.lambda$discoverComponents$0$ComponentRuntime(ComponentRuntime.java:132)
[OneSignal] 	at com.google.firebase.components.-$$Lambda$ComponentRuntime$4FqOW9eOQsvFYo-HpMfxCOnPQr0.get(lambda)
[OneSignal] 	at com.google.firebase.components.Lazy.get(Lazy.java:53)
[OneSignal] 	at com.google.firebase.components.ComponentRuntime.doInitializeEagerComponents(ComponentRuntime.java:291)
[OneSignal] 	at com.google.firebase.components.ComponentRuntime.initializeEagerComponents(ComponentRuntime.java:281)
[OneSignal] 	at com.google.firebase.FirebaseApp.initializeAllApis(FirebaseApp.java:584)
[OneSignal] 	at com.google.firebase.FirebaseApp.initializeApp(FirebaseApp.java:303)
[OneSignal] 	at com.onesignal.PushRegistratorFCM.initFirebaseApp(PushRegistratorFCM.java:175)
[OneSignal] 	at com.onesignal.PushRegistratorFCM.getToken(PushRegistratorFCM.java:107)
[OneSignal] 	at com.onesignal.PushRegistratorAbstractGoogle.attemptRegistration(PushRegistratorAbstractGoogle.java:97)
[OneSignal] 	at com.onesignal.PushRegistratorAbstractGoogle.access$100(PushRegistratorAbstractGoogle.java:37)
[OneSignal] 	at com.onesignal.PushRegistratorAbstractGoogle$1.run(PushRegistratorAbstractGoogle.java:84)
[OneSignal] 	at java.lang.Thread.run(Thread.java:818)
```

A 2nd stacktrace you will see that is related to the one above:
```java
[OneSignal] Unknown error getting FCM Token
[OneSignal] java.lang.IllegalStateException: FirebaseApp name ONESIGNAL_SDK_FCM_APP_NAME already exists!
[OneSignal] 	at com.google.android.gms.common.internal.Preconditions.checkState(com.google.android.gms:play-services-basement@@17.6.0:2)
[OneSignal] 	at com.google.firebase.FirebaseApp.initializeApp(FirebaseApp.java:294)
[OneSignal] 	at com.onesignal.PushRegistratorFCM.initFirebaseApp(PushRegistratorFCM.java:175)
[OneSignal] 	at com.onesignal.PushRegistratorFCM.getToken(PushRegistratorFCM.java:107)
[OneSignal] 	at com.onesignal.PushRegistratorAbstractGoogle.attemptRegistration(PushRegistratorAbstractGoogle.java:97)
[OneSignal] 	at com.onesignal.PushRegistratorAbstractGoogle.access$100(PushRegistratorAbstractGoogle.java:37)
[OneSignal] 	at java.lang.Thread.run(Thread.java:818)
```
However this is just a side effect the root issue is ` java.lang.NoClassDefFoundError: com.google.android.datatransport.runtime.ExecutionModule_ExecutorFactory`

## Which projects are effect?
This exact stacktrace noted here was taken from a 4.0.0-beta1 (pre-release) and it used `Xamarin.Firebase.Messaging@122.0.0.2`. However this is most likely an issue on the current OneSignal-Xamarin-SDK 3.x.x as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/252)
<!-- Reviewable:end -->
