### PR TITLE
Fix IOS building with OneSignal XCFramework for 4.0.0

### DIFF
--- a/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
+++ b/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>OneSignal.iOS.Binding</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignal.iOS.Binding</AssemblyName>
+    <NoBindingEmbedding>true</NoBindingEmbedding>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
+++ b/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
@@ -20,7 +20,6 @@
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchFastDev>true</MtouchFastDev>
     <IOSDebuggerPort>40540</IOSDebuggerPort>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
@@ -76,7 +75,6 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <MtouchExtraArgs>-v</MtouchExtraArgs>
-    <MtouchFastDev>true</MtouchFastDev>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
## Description
XCFrameworks require `<NoBindingEmbedding>true</NoBindingEmbedding>` on its binding project so consumers can link to it. This settings was referenced in https://github.com/xamarin/xamarin-macios/issues/10774#issuecomment-791518403.

It seems seems the consuming project (iOS sample project) can't use incremental builds as it also causes a linking error. Only an issue when building for a device, doesn't happen with the iPhoneSim target. This might be a Xamarin bug, however I haven't done a lot digging here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/254)
<!-- Reviewable:end -->
