### PR TITLE
Fix iOS link error for apps consuming `.nupkg` for 4.0.0

### DIFF
--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -40,5 +40,13 @@
 
         <!--Xamarin.iOS Unified-->
         <file src="Com.OneSignal.iOS\bin\Release\*OneSignal.*" target="lib\Xamarin.iOS10" />
+
+        <!-- Workaround to support .XCFramework for iOS  -->
+        <!-- Resources includes the full OneSignal.XCFramework.
+             iOS.Binding project has NoBindingEmbedding = true so it isn't also bundled in the .dll -->
+        <file src="OneSignal.iOS.Binding\bin\Release\OneSignal.iOS.Binding.resources\**" target="content\Com.OneSignal.iOS.resources" />
+        <!-- This is a .target files that gets used by project that consumes the NuGet package.
+             This copies out the OneSignal.xcframework from the resources folder and adds a NativeReference to it in the app project. -->
+        <file src="OneSignal.iOS.Binding\Com.OneSignal.targets" target="build\Xamarin.iOS10\" />
     </files>
 </package>

--- a/OneSignal.iOS.Binding/Com.OneSignal.targets
+++ b/OneSignal.iOS.Binding/Com.OneSignal.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="BeforeCompile">
+        <ItemGroup>
+            <BindingResources Include="$(MSBuildThisFileDirectory)../content/Com.OneSignal.iOS.resources/**/*.*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(BindingResources)" DestinationFolder="$(TargetDir)/Com.OneSignal.iOS.resources/%(RecursiveDir)" ContinueOnError="false" />
+        <ItemGroup>
+            <NativeReference Include="$(TargetDir)/Com.OneSignal.iOS.resources\OneSignal.xcframework">
+                <Kind>Framework</Kind>
+                <SmartLink>False</SmartLink>
+                <ForceLoad>True</ForceLoad>
+                <Frameworks>SystemConfiguration UserNotifications WebKit CoreGraphics UIKit</Frameworks>
+            </NativeReference>
+        </ItemGroup>
+    </Target>
+</Project>


### PR DESCRIPTION
## Description
Xamarin has limited support for `.xcframework` files, they do not have a built in working solution for NuGet packages yet. This works around the issue by including `OneSignal.xcframework` as-is in the `.nupkg`. It also includes a `.target` file which is settings to add the `OneSignal.xcframework` as a native reference. See the comment in the `Com.OneSignal.nuspec` file for more details.

The items under `<NativeReference>` in `Com.OneSignal.targets` is from `OneSignal.iOS.Binding.csproj` in this repo.

This was added based on the recommendations from:
   - https://github.com/xamarin/xamarin-macios/issues/10819#issuecomment-815059416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/255)
<!-- Reviewable:end -->
