### PR TITLE
Update iOS Notification Service Extension for 4.0.0

### DIFF
--- a/Com.OneSignal.iOS/Com.OneSignal.iOS.csproj
+++ b/Com.OneSignal.iOS/Com.OneSignal.iOS.csproj
@@ -47,6 +47,7 @@
     </Compile>
     <Compile Include="Utilities\NativeConversion.cs" />
     <Compile Include="OneSignalCallbacks.cs" />
+    <Compile Include="NotificationServiceExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Com.OneSignal.Core\Com.OneSignal.Core.csproj">

--- a/Com.OneSignal.iOS/NotificationServiceExtension.cs
+++ b/Com.OneSignal.iOS/NotificationServiceExtension.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using UserNotifications;
+
+namespace Com.OneSignal
+{
+   /// <summary>
+   /// Public SDK API to be consumed by the App's iOS NotificationServiceExtension target
+   /// </summary>
+   public partial class OneSignalImplementation
+   {
+      public UNMutableNotificationContent DidReceiveNotificationExtensionRequest(
+         UNNotificationRequest request,
+         UNMutableNotificationContent replacementContent,
+         Action<UNNotificationContent> contentHandler)
+      {
+         return iOS.OneSignal.DidReceiveNotificationExtensionRequest(
+            request,
+            replacementContent,
+            delegate (UNNotificationContent notificationContent)
+            {
+               contentHandler.Invoke(notificationContent);
+            }
+         );
+      }
+
+      public void ServiceExtensionTimeWillExpireRequest(
+         UNNotificationRequest request,
+         UNMutableNotificationContent replacementContent)
+      {
+         iOS.OneSignal.ServiceExtensionTimeWillExpireRequest(request, replacementContent);
+      }
+   }
+}

--- a/OneSignal.iOS.Binding/ApiDefinition.cs
+++ b/OneSignal.iOS.Binding/ApiDefinition.cs
@@ -760,7 +760,7 @@ namespace Com.OneSignal.iOS {
 		// +(UNMutableNotificationContent *)didReceiveNotificationExtensionRequest:(UNNotificationRequest * _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent * _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
 		[Static]
 		[Export("didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler:")]
-		UNMutableNotificationContent DidReceiveNotificationExtensionRequest(UNNotificationRequest request, [NullAllowed] UNMutableNotificationContent replacementContent, Action<UNNotificationContent> contentHandler);
+		UNMutableNotificationContent DidReceiveNotificationExtensionRequest(UNNotificationRequest request, [NullAllowed] UNMutableNotificationContent replacementContent, IosContentHandlerBlock contentHandler);
 
 		// +(UNMutableNotificationContent *)serviceExtensionTimeWillExpireRequest:(UNNotificationRequest * _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent * _Nullable)replacementContent;
 		[Static]
@@ -1079,4 +1079,6 @@ namespace Com.OneSignal.iOS {
 	// typedef void (^OSUpdateExternalUserIdSuccessBlock)(NSDictionary *);
 	delegate void OSUpdateExternalUserIdSuccessBlock(NSDictionary arg0);
 
+	// typedef (void (^)(UNNotificationContent *_Nonnull))contentHandler
+	delegate void IosContentHandlerBlock(UNNotificationContent arg0);
 }

--- a/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
+++ b/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
@@ -126,6 +126,10 @@
       <Project>{967EAABD-4A79-4762-9848-0D5530AA1FA5}</Project>
       <Name>OneSignal.iOS.Binding</Name>
     </ProjectReference>
+    <ProjectReference Include="..\OneSignalNotificationServiceExtension\OneSignalNotificationServiceExtension.csproj">
+      <IsAppExtension>true</IsAppExtension>
+      <Name>OneSignalNotificationServiceExtension</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Samples/OneSignalNotificationServiceExtension/Info.plist
+++ b/Samples/OneSignalNotificationServiceExtension/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>OneSignalNotificationServiceExtension</string>
+	<string>OneSignalNotificationServiceExtensionXamarin</string>
 	<key>CFBundleName</key>
-	<string>OneSignalNotificationServiceExtension</string>
+	<string>OneSignalNotificationServiceExtensionXamarin</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.onesignal.example.OneSignalNotificationServiceExtension</string>
+	<string>com.onesignal.example.OneSignalNotificationServiceExtensionXamarin</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Samples/OneSignalNotificationServiceExtension/NotificationService.cs
+++ b/Samples/OneSignalNotificationServiceExtension/NotificationService.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using Foundation;
-using UIKit;
 using UserNotifications;
 using Com.OneSignal;
-using Com.OneSignal.Abstractions;
 
 namespace OneSignalNotificationServiceExtension
 {
@@ -25,9 +23,7 @@ namespace OneSignalNotificationServiceExtension
       ContentHandler = contentHandler;
       BestAttemptContent = (UNMutableNotificationContent)request.Content.MutableCopy();
 
-      (OneSignal.Current as OneSignalImplementation).DidReceiveNotificationExtensionRequest(request, BestAttemptContent);
-
-      ContentHandler(BestAttemptContent);
+      (OneSignal.Default as OneSignalImplementation).DidReceiveNotificationExtensionRequest(request, BestAttemptContent, contentHandler);
     }
 
     public override void TimeWillExpire()
@@ -35,7 +31,7 @@ namespace OneSignalNotificationServiceExtension
       // Called just before the extension will be terminated by the system.
       // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
 
-      (OneSignal.Current as OneSignalImplementation).ServiceExtensionTimeWillExpireRequest(ReceivedRequest, BestAttemptContent);
+      (OneSignal.Default as OneSignalImplementation).ServiceExtensionTimeWillExpireRequest(ReceivedRequest, BestAttemptContent);
 
       ContentHandler(BestAttemptContent);
     }

--- a/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
+++ b/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
@@ -103,7 +103,7 @@
       <Project>{5FF66A21-BA7B-48FD-8A7D-6A1092066306}</Project>
       <Name>Com.OneSignal.iOS</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Com.OneSignal.Abstractions\Com.OneSignal.Abstractions.csproj">
+    <ProjectReference Include="..\..\Com.OneSignal.Core\Com.OneSignal.Core.csproj">
       <Project>{4A02EC63-E524-402B-8FD3-484FEFB172A1}</Project>
       <Name>Com.OneSignal.Core</Name>
     </ProjectReference>


### PR DESCRIPTION
# Description
## One Line Summary
Adds API and implementation to support the iOS NSE (Notification Service Extension) target in the OneSignal-Xamarin-SDK 4.0.0 API.

## Details
This also corrects some issues with the sample project setup with the NSE. Review commit-by-commit for more details.

## Testing
Tested on an iPhone 6s with iOS 14. Ensured images and action buttons displayed on the notification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/257)
<!-- Reviewable:end -->
