### PR TITLE
Fix iOS crash with NotificationWillShow delegate on 4.0.0

### DIFF
--- a/OneSignal.iOS.Binding/ApiDefinition.cs
+++ b/OneSignal.iOS.Binding/ApiDefinition.cs
@@ -261,9 +261,6 @@ namespace Com.OneSignal.iOS {
 		void OnDidDismissInAppMessage(OSInAppMessage message);
 	}
 
-	// typedef void (^OSNotificationDisplayResponse)(OSNotification * _Nullable);
-	delegate void OSNotificationDisplayResponse([NullAllowed] OSNotification arg0);
-
 	// @interface OSOutcomeEvent : NSObject
 	[BaseType(typeof(NSObject))]
 	interface OSOutcomeEvent {
@@ -1045,6 +1042,9 @@ namespace Com.OneSignal.iOS {
 
 	// typedef void (^OSUserResponseBlock)(BOOL);
 	delegate void OSUserResponseBlock(bool arg0);
+
+	// typedef void (^OSNotificationDisplayResponse)(OSNotification * _Nullable);
+	delegate void OSNotificationDisplayResponse([NullAllowed] OSNotification arg0);
 
 	// typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull, OSNotificationDisplayResponse _Nonnull);
 	delegate void OSNotificationWillShowInForegroundBlock(OSNotification arg0, [BlockCallback] OSNotificationDisplayResponse arg1);

--- a/OneSignal.iOS.Binding/ApiDefinition.cs
+++ b/OneSignal.iOS.Binding/ApiDefinition.cs
@@ -1047,7 +1047,7 @@ namespace Com.OneSignal.iOS {
 	delegate void OSUserResponseBlock(bool arg0);
 
 	// typedef void (^OSNotificationWillShowInForegroundBlock)(OSNotification * _Nonnull, OSNotificationDisplayResponse _Nonnull);
-	delegate void OSNotificationWillShowInForegroundBlock(OSNotification arg0, OSNotificationDisplayResponse arg1);
+	delegate void OSNotificationWillShowInForegroundBlock(OSNotification arg0, [BlockCallback] OSNotificationDisplayResponse arg1);
 
 	// typedef void (^OSNotificationOpenedBlock)(OSNotificationOpenedResult * _Nonnull);
 	delegate void OSNotificationOpenedBlock(OSNotificationOpenedResult arg0);


### PR DESCRIPTION
## Description
Fix "attempting to JIT" crash on notification received.
Added required `[BlockCallback]` to `OSNotificationWillShowInForegroundBlock` to fix.
This is prevents the following error:
   - `System.ExecutionEngineException: Attempting to JIT compile method '(wrapper managed-to-native)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/259)
<!-- Reviewable:end -->
