### PR TITLE
Update version to 4.0.0-beta1

### DIFF
--- a/Com.OneSignal.Android/Com.OneSignal.Android.csproj
+++ b/Com.OneSignal.Android/Com.OneSignal.Android.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidTlsProvider>
     </AndroidTlsProvider>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Com.OneSignal.Core/Com.OneSignal.Core.csproj
+++ b/Com.OneSignal.Core/Com.OneSignal.Core.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Com.OneSignal.iOS/Com.OneSignal.iOS.csproj
+++ b/Com.OneSignal.iOS/Com.OneSignal.iOS.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Com.OneSignal</RootNamespace>
     <AssemblyName>Com.OneSignal</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <IOSDebuggerPort>59137</IOSDebuggerPort>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.OneSignal</id>
-        <version>3.10.6</version>
+        <version>4.0.0-beta1</version>
         <title>OneSignal SDK for Xamarin</title>
         <authors>OneSignal, Martijn van Dijk</authors>
         <owners>OneSignal</owners>

--- a/Com.OneSignal/Com.OneSignal.csproj
+++ b/Com.OneSignal/Com.OneSignal.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -14,6 +14,7 @@
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
     <AndroidClassParser>class-parse</AndroidClassParser>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
+++ b/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
@@ -10,6 +10,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignal.iOS.Binding</AssemblyName>
     <NoBindingEmbedding>true</NoBindingEmbedding>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.sln
+++ b/OneSignal.sln
@@ -173,4 +173,7 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC536039-9077-48EA-BEAB-432B3B21D933}
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		version = 4.0.0-beta1
+	EndGlobalSection
 EndGlobal

--- a/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
+++ b/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
@@ -17,6 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/Com.OneSignal.Sample.Shared/Com.OneSignal.Sample.Shared.csproj
+++ b/Samples/Com.OneSignal.Sample.Shared/Com.OneSignal.Sample.Shared.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
+++ b/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Com.OneSignal.Sample.iOS</RootNamespace>
     <AssemblyName>Com.OneSignal.Sample.iOS</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
+++ b/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>OneSignalNotificationServiceExtension</RootNamespace>
     <AssemblyName>OneSignalNotificationServiceExtension</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <ReleaseVersion>4.0.0-beta1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### OneSignal Xamarin SDK Beta Release 4.0.0-beta1

### Bindings
* Added OneSignal iOS version 3.9.1
* Added OneSignal Android version 4.6.3
* iOS - Edited ApiDefinition to create Bindings from .aar file
* iOS - Updated Structs.cs for iOS native enums
* Android - Updated Project settings to use class parse instead of jar2xml as jar file parser
* Android - Updated Project settings to remove `Java.Interop` package

### OneSignal.Core
* Deleted files in OneSignal.Abstraction
* Renamed project and namespace to OneSignal.Abstraction to OneSignal.Core
* Added abstract partial class `OneSignalSDK` to OneSignal.Core
* Added enums LogType and LogoutOptions in OneSignal.Core
* Added Json and Laters helper classes

### OneSignal.Android
* Removed Additional classes from OneSignal.Android
* Added OneSignal Android implementation for OneSignal SDK abstract partial class
* Added Android callback classes that use Later
* Added helper class for conversion of Android native state to Xamarin states.
* Added AndroidX, Firebase messaging, and Kotlin related packages OneSignal.Android

### OneSignal.iOS
* Added OneSignal iOS implementation for OneSignal SDK abstract partial class
* Added iOS callback classes that use Later
* Added helper class for conversion of iOS native state to Xamarin states.

### Com.OneSignal
* Replaced the IOneSignal interface with OneSignalSDK abstract partial class

### Sample Apps
* Updated with new Apis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/261)
<!-- Reviewable:end -->
