### PR TITLE
State Getter Implementations and Null Reference crash fix

### DIFF
--- a/Com.OneSignal.Android/Com.OneSignal.Android.csproj
+++ b/Com.OneSignal.Android/Com.OneSignal.Android.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.props')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.props')" />
   <Import Project="..\packages\Xamarin.AndroidX.Migration.1.0.8\build\monoandroid90\Xamarin.AndroidX.Migration.props" Condition="Exists('..\packages\Xamarin.AndroidX.Migration.1.0.8\build\monoandroid90\Xamarin.AndroidX.Migration.props')" />
   <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props')" />
   <PropertyGroup>
@@ -128,7 +128,7 @@
       <HintPath>..\packages\Xamarin.AndroidX.AppCompat.1.3.1.3\lib\monoandroid90\Xamarin.AndroidX.AppCompat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Guava.ListenableFuture">
-      <HintPath>..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.4\lib\monoandroid90\Xamarin.Google.Guava.ListenableFuture.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\lib\monoandroid90\Xamarin.Google.Guava.ListenableFuture.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.AndroidX.Concurrent.Futures">
       <HintPath>..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\lib\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.dll</HintPath>
@@ -197,62 +197,62 @@
       <HintPath>..\packages\Xamarin.AndroidX.Work.Runtime.2.7.0\lib\monoandroid90\Xamarin.AndroidX.Work.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Annotations">
-      <HintPath>..\packages\Xamarin.Firebase.Annotations.116.0.0.2\lib\monoandroid90\Xamarin.Firebase.Annotations.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Annotations.116.0.0.3\lib\monoandroid90\Xamarin.Firebase.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="Xamarin.Firebase.Components">
-      <HintPath>..\packages\Xamarin.Firebase.Components.117.0.0.2\lib\monoandroid90\Xamarin.Firebase.Components.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Components.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Components.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Android.DataTransport.TransportApi">
-      <HintPath>..\packages\Xamarin.Google.Android.DataTransport.TransportApi.3.0.0\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportApi.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Google.Android.DataTransport.TransportApi.3.0.0.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportApi.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct">
-      <HintPath>..\packages\Xamarin.Google.Android.DataTransport.TransportBackendCct.3.0.0\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportBackendCct.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Google.Android.DataTransport.TransportBackendCct.3.0.0.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportBackendCct.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Android.DataTransport.TransportRuntime">
-      <HintPath>..\packages\Xamarin.Google.Android.DataTransport.TransportRuntime.3.0.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportRuntime.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Google.Android.DataTransport.TransportRuntime.3.0.1.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Basement">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.Basement.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.4\lib\monoandroid90\Xamarin.GooglePlayServices.Basement.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Measurement.Connector">
-      <HintPath>..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.2\lib\monoandroid90\Xamarin.Firebase.Measurement.Connector.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.3\lib\monoandroid90\Xamarin.Firebase.Measurement.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Stats">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.2\lib\monoandroid90\Xamarin.GooglePlayServices.Stats.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.3\lib\monoandroid90\Xamarin.GooglePlayServices.Stats.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Tasks">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.2\lib\monoandroid90\Xamarin.GooglePlayServices.Tasks.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.3\lib\monoandroid90\Xamarin.GooglePlayServices.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Common">
-      <HintPath>..\packages\Xamarin.Firebase.Common.120.0.0.2\lib\monoandroid90\Xamarin.Firebase.Common.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Common.120.0.0.3\lib\monoandroid90\Xamarin.Firebase.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Datatransport">
-      <HintPath>..\packages\Xamarin.Firebase.Datatransport.118.0.1.2\lib\monoandroid90\Xamarin.Firebase.Datatransport.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Datatransport.118.0.1.3\lib\monoandroid90\Xamarin.Firebase.Datatransport.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Iid.Interop">
-      <HintPath>..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.2\lib\monoandroid90\Xamarin.Firebase.Iid.Interop.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.3\lib\monoandroid90\Xamarin.Firebase.Iid.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Installations.InterOp">
-      <HintPath>..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.2\lib\monoandroid90\Xamarin.Firebase.Installations.InterOp.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Installations.InterOp.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Installations">
-      <HintPath>..\packages\Xamarin.Firebase.Installations.117.0.0.2\lib\monoandroid90\Xamarin.Firebase.Installations.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Installations.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Installations.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.CloudMessaging">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.2\lib\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Messaging">
-      <HintPath>..\packages\Xamarin.Firebase.Messaging.122.0.0.2\lib\monoandroid90\Xamarin.Firebase.Messaging.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Firebase.Messaging.122.0.0.3\lib\monoandroid90\Xamarin.Firebase.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Base">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Base.117.6.0.2\lib\monoandroid90\Xamarin.GooglePlayServices.Base.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.Base.117.6.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.Base.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Places.PlaceReport">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Places.PlaceReport.117.0.0.2\lib\monoandroid90\Xamarin.GooglePlayServices.Places.PlaceReport.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.Places.PlaceReport.117.0.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.Places.PlaceReport.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Location">
-      <HintPath>..\packages\Xamarin.GooglePlayServices.Location.118.0.0.2\lib\monoandroid90\Xamarin.GooglePlayServices.Location.dll</HintPath>
+      <HintPath>..\packages\Xamarin.GooglePlayServices.Location.118.0.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.Location.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Jetbrains.Annotations">
       <HintPath>..\packages\Xamarin.Jetbrains.Annotations.22.0.0.2\lib\monoandroid90\Xamarin.Jetbrains.Annotations.dll</HintPath>
@@ -262,6 +262,19 @@
     </Reference>
     <Reference Include="Xamarin.Kotlin.StdLib">
       <HintPath>..\packages\Xamarin.Kotlin.StdLib.1.5.31.2\lib\monoandroid90\Xamarin.Kotlin.StdLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Java.Interop" />
+    <Reference Include="Xamarin.Firebase.Encoders">
+      <HintPath>..\packages\Xamarin.Firebase.Encoders.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Encoders.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Firebase.Encoders.JSON">
+      <HintPath>..\packages\Xamarin.Firebase.Encoders.JSON.118.0.0.3\lib\monoandroid90\Xamarin.Firebase.Encoders.JSON.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.JavaX.Inject">
+      <HintPath>..\packages\Xamarin.JavaX.Inject.1.0.0.2\lib\monoandroid90\Xamarin.JavaX.Inject.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Essentials">
+      <HintPath>..\packages\Xamarin.Essentials.1.7.1\lib\monoandroid10.0\Xamarin.Essentials.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -314,7 +327,6 @@
   <Import Project="..\packages\Xamarin.AndroidX.ViewPager.1.0.0.10\build\monoandroid90\Xamarin.AndroidX.ViewPager.targets" Condition="Exists('..\packages\Xamarin.AndroidX.ViewPager.1.0.0.10\build\monoandroid90\Xamarin.AndroidX.ViewPager.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Fragment.1.3.6.3\build\monoandroid90\Xamarin.AndroidX.Fragment.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Fragment.1.3.6.3\build\monoandroid90\Xamarin.AndroidX.Fragment.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.AppCompat.1.3.1.3\build\monoandroid90\Xamarin.AndroidX.AppCompat.targets" Condition="Exists('..\packages\Xamarin.AndroidX.AppCompat.1.3.1.3\build\monoandroid90\Xamarin.AndroidX.AppCompat.targets')" />
-  <Import Project="..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.4\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets" Condition="Exists('..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.4\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\build\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\build\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Browser.1.3.0.8\build\monoandroid90\Xamarin.AndroidX.Browser.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Browser.1.3.0.8\build\monoandroid90\Xamarin.AndroidX.Browser.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.CardView.1.0.0.11\build\monoandroid90\Xamarin.AndroidX.CardView.targets" Condition="Exists('..\packages\Xamarin.AndroidX.CardView.1.0.0.11\build\monoandroid90\Xamarin.AndroidX.CardView.targets')" />
@@ -336,26 +348,29 @@
   <Import Project="..\packages\Xamarin.AndroidX.Room.Runtime.2.3.0.4\build\monoandroid90\Xamarin.AndroidX.Room.Runtime.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Room.Runtime.2.3.0.4\build\monoandroid90\Xamarin.AndroidX.Room.Runtime.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Startup.StartupRuntime.1.1.0.2\build\monoandroid90\Xamarin.AndroidX.Startup.StartupRuntime.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Startup.StartupRuntime.1.1.0.2\build\monoandroid90\Xamarin.AndroidX.Startup.StartupRuntime.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Work.Runtime.2.7.0\build\monoandroid90\Xamarin.AndroidX.Work.Runtime.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Work.Runtime.2.7.0\build\monoandroid90\Xamarin.AndroidX.Work.Runtime.targets')" />
-  <Import Project="..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Annotations.116.0.0.2\build\monoandroid90\Xamarin.Firebase.Annotations.targets" Condition="Exists('..\packages\Xamarin.Firebase.Annotations.116.0.0.2\build\monoandroid90\Xamarin.Firebase.Annotations.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Components.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Components.targets" Condition="Exists('..\packages\Xamarin.Firebase.Components.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Components.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.2\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets" Condition="Exists('..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.2\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Common.120.0.0.2\build\monoandroid90\Xamarin.Firebase.Common.targets" Condition="Exists('..\packages\Xamarin.Firebase.Common.120.0.0.2\build\monoandroid90\Xamarin.Firebase.Common.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Datatransport.118.0.1.2\build\monoandroid90\Xamarin.Firebase.Datatransport.targets" Condition="Exists('..\packages\Xamarin.Firebase.Datatransport.118.0.1.2\build\monoandroid90\Xamarin.Firebase.Datatransport.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.2\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets" Condition="Exists('..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.2\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets" Condition="Exists('..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Installations.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.targets" Condition="Exists('..\packages\Xamarin.Firebase.Installations.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets')" />
-  <Import Project="..\packages\Xamarin.Firebase.Messaging.122.0.0.2\build\monoandroid90\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\packages\Xamarin.Firebase.Messaging.122.0.0.2\build\monoandroid90\Xamarin.Firebase.Messaging.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Base.117.6.0.2\build\monoandroid90\Xamarin.GooglePlayServices.Base.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Base.117.6.0.2\build\monoandroid90\Xamarin.GooglePlayServices.Base.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Places.PlaceReport.117.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.Places.PlaceReport.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Places.PlaceReport.117.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.Places.PlaceReport.targets')" />
-  <Import Project="..\packages\Xamarin.GooglePlayServices.Location.118.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.Location.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Location.118.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.Location.targets')" />
   <Import Project="..\packages\Xamarin.Jetbrains.Annotations.22.0.0.2\build\monoandroid90\Xamarin.Jetbrains.Annotations.targets" Condition="Exists('..\packages\Xamarin.Jetbrains.Annotations.22.0.0.2\build\monoandroid90\Xamarin.Jetbrains.Annotations.targets')" />
   <Import Project="..\packages\Xamarin.Kotlin.StdLib.Common.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.Common.targets" Condition="Exists('..\packages\Xamarin.Kotlin.StdLib.Common.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.Common.targets')" />
   <Import Project="..\packages\Xamarin.Kotlin.StdLib.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.targets" Condition="Exists('..\packages\Xamarin.Kotlin.StdLib.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.MultiDex.2.0.1.10\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets" Condition="Exists('..\packages\Xamarin.AndroidX.MultiDex.2.0.1.10\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Media.1.4.3\build\monoandroid90\Xamarin.AndroidX.Media.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Media.1.4.3\build\monoandroid90\Xamarin.AndroidX.Media.targets')" />
+  <Import Project="..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Annotations.116.0.0.3\build\monoandroid90\Xamarin.Firebase.Annotations.targets" Condition="Exists('..\packages\Xamarin.Firebase.Annotations.116.0.0.3\build\monoandroid90\Xamarin.Firebase.Annotations.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Components.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Components.targets" Condition="Exists('..\packages\Xamarin.Firebase.Components.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Components.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Encoders.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.targets" Condition="Exists('..\packages\Xamarin.Firebase.Encoders.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Encoders.JSON.118.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.JSON.targets" Condition="Exists('..\packages\Xamarin.Firebase.Encoders.JSON.118.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.JSON.targets')" />
+  <Import Project="..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets" Condition="Exists('..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.4\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.4\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.3\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets" Condition="Exists('..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.3\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.Places.PlaceReport.117.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Places.PlaceReport.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Places.PlaceReport.117.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Places.PlaceReport.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Common.120.0.0.3\build\monoandroid90\Xamarin.Firebase.Common.targets" Condition="Exists('..\packages\Xamarin.Firebase.Common.120.0.0.3\build\monoandroid90\Xamarin.Firebase.Common.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.3\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets" Condition="Exists('..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.3\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets" Condition="Exists('..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Installations.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.targets" Condition="Exists('..\packages\Xamarin.Firebase.Installations.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.Base.117.6.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Base.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Base.117.6.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Base.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets')" />
+  <Import Project="..\packages\Xamarin.GooglePlayServices.Location.118.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Location.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Location.118.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Location.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Datatransport.118.0.1.3\build\monoandroid90\Xamarin.Firebase.Datatransport.targets" Condition="Exists('..\packages\Xamarin.Firebase.Datatransport.118.0.1.3\build\monoandroid90\Xamarin.Firebase.Datatransport.targets')" />
+  <Import Project="..\packages\Xamarin.Firebase.Messaging.122.0.0.3\build\monoandroid90\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\packages\Xamarin.Firebase.Messaging.122.0.0.3\build\monoandroid90\Xamarin.Firebase.Messaging.targets')" />
 </Project>

--- a/Com.OneSignal.Android/OneSignalCallbacks.cs
+++ b/Com.OneSignal.Android/OneSignalCallbacks.cs
@@ -33,16 +33,6 @@ namespace Com.OneSignal {
             Debug.WriteLine("Additional instance of OneSignalAndroid created.");
          }
 
-         OneSignalNative.AddPermissionObserver(new OSPermissionObserver());
-         OneSignalNative.AddSubscriptionObserver(new OSPushSubscriptionObserver());
-         OneSignalNative.AddEmailSubscriptionObserver(new OSEmailSubscriptionObserver());
-         OneSignalNative.AddSMSSubscriptionObserver(new OSSMSSubscriptionObserver());
-
-         OneSignalNative.SetNotificationWillShowInForegroundHandler(new OSNotificationWillShowInForegroundHandler());
-         OneSignalNative.SetNotificationOpenedHandler(new OSNotificationOpenedHandler());
-         OneSignalNative.SetInAppMessageClickHandler(new OSInAppMessageClickHandler());
-         OneSignalNative.SetInAppMessageLifecycleHandler(new OSInAppMessageLifeCycleHandler());
-
          _instance = this;
       }
 
@@ -50,8 +40,8 @@ namespace Com.OneSignal {
       private sealed class OSPermissionObserver : Java.Lang.Object, Android.IOSPermissionObserver {
          /// <param name="stateChanges">OSPermissionStateChanges</param>
          public void OnOSPermissionChanged(Android.OSPermissionStateChanges stateChanges) {
-            PermissionState prev = NativeConversion.PermissionStateToXam(stateChanges.From);
-            PermissionState curr = NativeConversion.PermissionStateToXam(stateChanges.To);
+            NotificationPermission prev = NativeConversion.PermissionStateToXam(stateChanges.From.AreNotificationsEnabled());
+            NotificationPermission curr = NativeConversion.PermissionStateToXam(stateChanges.To.AreNotificationsEnabled());
             _instance.PermissionStateChanged?.Invoke(curr, prev);
          }
       }

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -7,6 +7,7 @@ using Com.OneSignal.Core;
 
 using Android.App;
 using Android.Content;
+
 using OneSignalNative = Com.OneSignal.Android.OneSignal;
 
 namespace Com.OneSignal {
@@ -39,8 +40,18 @@ namespace Com.OneSignal {
 
       public override void Initialize(string appId) {
          Context context = Application.Context;
-         OneSignalNative.InitWithContext(context);
          OneSignalNative.SetAppId(appId);
+         OneSignalNative.InitWithContext(context);
+
+         OneSignalNative.AddPermissionObserver(new OSPermissionObserver());
+         OneSignalNative.AddSubscriptionObserver(new OSPushSubscriptionObserver());
+         OneSignalNative.AddEmailSubscriptionObserver(new OSEmailSubscriptionObserver());
+         OneSignalNative.AddSMSSubscriptionObserver(new OSSMSSubscriptionObserver());
+
+         OneSignalNative.SetNotificationWillShowInForegroundHandler(new OSNotificationWillShowInForegroundHandler());
+         OneSignalNative.SetNotificationOpenedHandler(new OSNotificationOpenedHandler());
+         OneSignalNative.SetInAppMessageClickHandler(new OSInAppMessageClickHandler());
+         OneSignalNative.SetInAppMessageLifecycleHandler(new OSInAppMessageLifeCycleHandler());
       }
 
       public override Task<NotificationPermission> PromptForPushNotificationsWithUserResponse() {

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -22,7 +22,7 @@ namespace Com.OneSignal {
       public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
       public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
       public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-      public override event StateChangeDelegate<PermissionState> PermissionStateChanged;
+      public override event StateChangeDelegate<NotificationPermission> PermissionStateChanged;
       public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
       public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
       public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
@@ -97,6 +97,45 @@ namespace Com.OneSignal {
          OSSMSUpdateHandler handler = new OSSMSUpdateHandler();
          OneSignalNative.LogoutSMSNumber(handler);
          return await handler;
+      }
+
+      public override DeviceState DeviceState => NativeConversion.DeviceStateToXam(OneSignalNative.DeviceState);
+
+      public override NotificationPermission NotificationPermission {
+         get {
+            return DeviceState.notificationPermission;
+         }
+      }
+
+      public override PushSubscriptionState PushSubscriptionState {
+         get {
+            return new PushSubscriptionState {
+               userId = DeviceState.userId,
+               pushToken = DeviceState.pushToken,
+               isSubscribed = DeviceState.isSubscribed,
+               isPushDisabled = DeviceState.isPushDisabled
+            };
+         }
+      }
+
+      public override EmailSubscriptionState EmailSubscriptionState {
+         get {
+            return new EmailSubscriptionState {
+               emailUserId = DeviceState.emailUserId,
+               emailAddress = DeviceState.emailAddress,
+               isSubscribed = DeviceState.isEmailSubscribed
+            };
+         }
+      }
+
+      public override SMSSubscriptionState SMSSubscriptionState {
+         get {
+            return new SMSSubscriptionState {
+               smsUserId = DeviceState.smsUserId,
+               smsNumber = DeviceState.smsNumber,
+               isSubscribed = DeviceState.isSMSSubscribed
+            };
+         }
       }
 
       public override void SetLanguage(string language) {

--- a/Com.OneSignal.Android/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.Android/Utilities/NativeConversion.cs
@@ -90,10 +90,25 @@ namespace Com.OneSignal {
          };
       }
 
-      public static PermissionState PermissionStateToXam(Android.OSPermissionState androidPermissionState) {
-         return new PermissionState {
-            status = androidPermissionState.AreNotificationsEnabled() ? NotificationPermission.Authorized : NotificationPermission.Denied
+      public static DeviceState DeviceStateToXam(Android.OSDeviceState deviceState) {
+         return new DeviceState {
+            notificationPermission = PermissionStateToXam(deviceState.AreNotificationsEnabled()),
+            areNotificationsEnabled = deviceState.AreNotificationsEnabled(),
+            isSubscribed = deviceState.IsSubscribed,
+            userId = deviceState.UserId,
+            pushToken = deviceState.PushToken,
+            isPushDisabled = deviceState.IsPushDisabled,
+            isEmailSubscribed = deviceState.IsEmailSubscribed,
+            emailUserId = deviceState.EmailUserId,
+            emailAddress = deviceState.EmailAddress,
+            isSMSSubscribed = deviceState.IsSMSSubscribed,
+            smsNumber = deviceState.SMSNumber,
+            smsUserId = deviceState.SMSUserId
          };
+      }
+
+      public static NotificationPermission PermissionStateToXam(bool areNotificationsEnabled) {
+         return areNotificationsEnabled ? NotificationPermission.Authorized : NotificationPermission.Denied;
       }
 
       public static PushSubscriptionState PushSubscriptionStateToXam(Android.OSSubscriptionState androidSubscriptionState) {

--- a/Com.OneSignal.Android/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.Android/Utilities/NativeConversion.cs
@@ -10,13 +10,9 @@ namespace Com.OneSignal {
       public static Notification NotificationToXam(Android.OSNotification notification) {
          Notification nativeNotification = new Notification {
             androidNotificationId = notification.AndroidNotificationId,
-            groupedNotifications = new List<Notification>(),
             notificationId = notification.NotificationId,
-            templateName = notification.TemplateName,
-            templateId = notification.TemplateId,
             title = notification.Title,
             body = notification.Body,
-            additionalData = Json.Deserialize(notification.AdditionalData.ToString()) as Dictionary<string, object>,
             smallIcon = notification.SmallIcon,
             largeIcon = notification.LargeIcon,
             bigPicture = notification.BigPicture,
@@ -32,16 +28,26 @@ namespace Com.OneSignal {
             priority = notification.Priority,
             rawPayload = notification.RawPayload,
          };
-         foreach (var individualNotification in notification.GroupedNotifications)
-            nativeNotification.groupedNotifications.Add(NotificationToXam(individualNotification));
 
-         nativeNotification.actionButtons = new List<ActionButton>();
-         foreach (var actionButton in notification.ActionButtons)
-            nativeNotification.actionButtons.Add(new ActionButton(actionButton.Id, actionButton.Text, actionButton.Icon));
+         if (notification.AdditionalData != null)
+            nativeNotification.additionalData = Json.Deserialize(notification.AdditionalData.ToString()) as Dictionary<string, object>;
 
-         nativeNotification.backgroundImageLayout = new BackgroundImageLayout(notification.GetBackgroundImageLayout().Image,
-            notification.GetBackgroundImageLayout().TitleTextColor,
-            notification.GetBackgroundImageLayout().BodyTextColor);
+         if (notification.GroupedNotifications != null) {
+            foreach (var individualNotification in notification.GroupedNotifications)
+               nativeNotification.groupedNotifications.Add(NotificationToXam(individualNotification));
+         }
+
+         if (notification.ActionButtons != null) {
+            nativeNotification.actionButtons = new List<ActionButton>();
+            foreach (var actionButton in notification.ActionButtons)
+               nativeNotification.actionButtons.Add(new ActionButton(actionButton.Id, actionButton.Text, actionButton.Icon));
+         }
+
+         if (notification.GetBackgroundImageLayout() != null) {
+            nativeNotification.backgroundImageLayout = new BackgroundImageLayout(notification.GetBackgroundImageLayout().Image,
+               notification.GetBackgroundImageLayout().TitleTextColor,
+               notification.GetBackgroundImageLayout().BodyTextColor);
+         }
 
          return nativeNotification;
       }

--- a/Com.OneSignal.Android/packages.config
+++ b/Com.OneSignal.Android/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NuGet.Build.Packaging" version="0.2.2" targetFramework="monoandroid11.0" developmentDependency="true" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.Activity" version="1.3.1.2" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.Annotation" version="1.2.0.3" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.Annotation.Experimental" version="1.1.0.3" targetFramework="monoandroid11.0" />
@@ -51,27 +52,31 @@
   <package id="Xamarin.AndroidX.VersionedParcelable" version="1.1.1.10" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.ViewPager" version="1.0.0.10" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.Work.Runtime" version="2.7.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Build.Download" version="0.10.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Annotations" version="116.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Common" version="120.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Components" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Datatransport" version="118.0.1.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Iid.Interop" version="117.1.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Installations" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Installations.InterOp" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Measurement.Connector" version="119.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Messaging" version="122.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportApi" version="3.0.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportBackendCct" version="3.0.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportRuntime" version="3.0.1" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.4" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Base" version="117.6.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="117.6.0.3" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.CloudMessaging" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Location" version="118.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Places.PlaceReport" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Stats" version="117.0.1.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Tasks" version="117.2.1.2" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Build.Download" version="0.11.0" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Essentials" version="1.7.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Annotations" version="116.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Common" version="120.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Components" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Datatransport" version="118.0.1.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Encoders" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Encoders.JSON" version="118.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Iid.Interop" version="117.1.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Installations" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Installations.InterOp" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Measurement.Connector" version="119.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Messaging" version="122.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Android.DataTransport.TransportApi" version="3.0.0.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Android.DataTransport.TransportBackendCct" version="3.0.0.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Android.DataTransport.TransportRuntime" version="3.0.1.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.5" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Base" version="117.6.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Basement" version="117.6.0.4" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.CloudMessaging" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Location" version="118.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Places.PlaceReport" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Stats" version="117.0.1.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Tasks" version="117.2.1.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.JavaX.Inject" version="1.0.0.2" targetFramework="monoandroid11.0" />
   <package id="Xamarin.Jetbrains.Annotations" version="22.0.0.2" targetFramework="monoandroid11.0" />
   <package id="Xamarin.Kotlin.StdLib" version="1.5.31.2" targetFramework="monoandroid11.0" />
   <package id="Xamarin.Kotlin.StdLib.Common" version="1.5.31.2" targetFramework="monoandroid11.0" />

--- a/Com.OneSignal.Core/DeviceState.cs
+++ b/Com.OneSignal.Core/DeviceState.cs
@@ -1,0 +1,30 @@
+﻿using System;
+namespace Com.OneSignal.Core {
+   [Serializable]
+   public sealed class DeviceState {
+
+      public NotificationPermission notificationPermission;
+
+      public bool areNotificationsEnabled;
+
+      public bool isSubscribed;
+
+      public string userId;
+
+      public string pushToken;
+
+      public bool isPushDisabled;
+
+      public bool isEmailSubscribed;
+
+      public string emailUserId;
+
+      public string emailAddress;
+
+      public bool isSMSSubscribed;
+
+      public string smsNumber;
+
+      public string smsUserId;
+   }
+}

--- a/Com.OneSignal.Core/NotificationPermission.cs
+++ b/Com.OneSignal.Core/NotificationPermission.cs
@@ -21,11 +21,4 @@ namespace Com.OneSignal.Core {
       /// <summary>The application is authorized to send notifications for 8 hours. Only used by App Clips.</summary>
       Ephemeral
    }
-
-   [Serializable]
-   public sealed class PermissionState {
-      public bool hasPrompted;
-      public NotificationPermission status;
-      public bool provisional;
-   }
 }

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -60,6 +60,10 @@ namespace Com.OneSignal.Core {
       /// </summary>
       public abstract event NotificationActionDelegate NotificationWasOpened;
 
+      /*
+       * In App Messages 
+       */
+
       /// <summary>
       /// When a user has chosen to dismiss an In-App Message
       /// </summary>
@@ -148,6 +152,11 @@ namespace Com.OneSignal.Core {
       public abstract Task<NotificationPermission> PromptForPushNotificationsWithUserResponse();
 
       /// <summary>
+      /// Removes all OneSignal app notifications from the Notification Shade
+      /// </summary>
+      public abstract void ClearOneSignalNotifications();
+
+      /// <summary>
       /// Allows you to send notifications from user to user or schedule ones in the future to be delivered to the
       /// current device.
       /// </summary>
@@ -159,11 +168,6 @@ namespace Com.OneSignal.Core {
       /// {@code tags} and {@code included_segments} require your OneSignal App REST API key which can only be used
       /// from your server.</remarks>
       public abstract Task<bool> PostNotification(Dictionary<string, object> options);
-
-      /// <summary>
-      /// Removes all OneSignal app notifications from the Notification Shade
-      /// </summary>
-      public abstract void ClearOneSignalNotifications();
       #endregion
 
       #region In App Messages
@@ -277,14 +281,6 @@ namespace Com.OneSignal.Core {
       /// your users. Your backend can generate an email authentication token and send it to your app.</param>
       /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
       public abstract Task<bool> SetSMSNumber(string smsNumber, string authHash = null);
-
-      ///// <summary>
-      ///// If your app implements logout functionality, you can call Logout to dissociate the email, sms, and/or
-      ///// external user id from the device
-      ///// </summary>
-      //public abstract Task<bool> Logout(
-      //    LogoutOptions options = LogoutOptions.Email | LogoutOptions.SMS | LogoutOptions.ExternalUserId
-      //);
 
       ///<summary>
       ///If this user logs out of your app and/or you would like to disassociate their external user id with

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -90,7 +90,7 @@ namespace Com.OneSignal.Core {
       /// <summary>
       /// When this device's permissions for authorization of push notifications have changed.
       /// </summary>
-      public abstract event StateChangeDelegate<PermissionState> PermissionStateChanged;
+      public abstract event StateChangeDelegate<NotificationPermission> PermissionStateChanged;
 
       /// <summary>
       /// When this device's subscription to push notifications has changed
@@ -245,7 +245,7 @@ namespace Com.OneSignal.Core {
       #endregion
 
 
-      #region User Identification
+      #region User & Device Properties
       /// <summary>
       /// Allows you to use your own application's user id to send OneSignal messages to your user. To tie the user
       /// to a given user id, you can use this method.
@@ -305,6 +305,30 @@ namespace Com.OneSignal.Core {
       /// </summary>
       /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
       public abstract Task<bool> LogoutSMS();
+
+      ///<summary>
+      ///</summary>
+      public abstract DeviceState DeviceState { get; }
+
+      /// <summary>
+      /// Current status of permissions granted by this device for push notifications
+      /// </summary>
+      public abstract NotificationPermission NotificationPermission { get; }
+
+      /// <summary>
+      /// Current status of this device's subscription to push notifications
+      /// </summary>
+      public abstract PushSubscriptionState PushSubscriptionState { get; }
+
+      /// <summary>
+      /// Current status of this device's subscription to email
+      /// </summary>
+      public abstract EmailSubscriptionState EmailSubscriptionState { get; }
+
+      /// <summary>
+      /// Current status of this device's subscription to sms
+      /// </summary>
+      public abstract SMSSubscriptionState SMSSubscriptionState { get; }
       #endregion
 
       /// <summary>

--- a/Com.OneSignal.iOS/OneSignalCallbacks.cs
+++ b/Com.OneSignal.iOS/OneSignalCallbacks.cs
@@ -72,8 +72,8 @@ namespace Com.OneSignal {
 
       private sealed class OSPermissionObserver : iOS.OSPermissionObserver {
          public override void OnOSPermissionChanged(iOS.OSPermissionStateChanges permissionStateChanges) {
-            PermissionState from = NativeConversion.PermissionStateToXam(permissionStateChanges.From);
-            PermissionState to = NativeConversion.PermissionStateToXam(permissionStateChanges.To);
+            NotificationPermission from = NativeConversion.PermissionStateToXam(permissionStateChanges.From);
+            NotificationPermission to = NativeConversion.PermissionStateToXam(permissionStateChanges.To);
 
             _instance.PermissionStateChanged?.Invoke(to, from);
          }

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -20,7 +20,7 @@ namespace Com.OneSignal {
       public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
       public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
       public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-      public override event StateChangeDelegate<PermissionState> PermissionStateChanged;
+      public override event StateChangeDelegate<NotificationPermission> PermissionStateChanged;
       public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
       public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
       public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
@@ -96,6 +96,45 @@ namespace Com.OneSignal {
          BooleanCallbackProxy proxy = new BooleanCallbackProxy();
          OneSignalNative.LogoutSMSNumberWithSuccess(response => proxy.OnResponse(true), response => proxy.OnResponse(false));
          return await proxy;
+      }
+
+      public override DeviceState DeviceState => NativeConversion.DeviceStateToXam(OneSignalNative.DeviceState());
+
+      public override NotificationPermission NotificationPermission {
+         get {
+            return DeviceState.notificationPermission;
+         }
+      }
+
+      public override PushSubscriptionState PushSubscriptionState {
+         get {
+            return new PushSubscriptionState {
+               userId = DeviceState.userId,
+               pushToken = DeviceState.pushToken,
+               isSubscribed = DeviceState.isSubscribed,
+               isPushDisabled = DeviceState.isPushDisabled
+            };
+         }
+      }
+
+      public override EmailSubscriptionState EmailSubscriptionState {
+         get {
+            return new EmailSubscriptionState {
+               emailUserId = DeviceState.emailUserId,
+               emailAddress = DeviceState.emailAddress,
+               isSubscribed = DeviceState.isEmailSubscribed
+            };
+         }
+      }
+
+      public override SMSSubscriptionState SMSSubscriptionState {
+         get {
+            return new SMSSubscriptionState {
+               smsUserId = DeviceState.smsUserId,
+               smsNumber = DeviceState.smsNumber,
+               isSubscribed = DeviceState.isSMSSubscribed
+            }
+         }
       }
 
       public override void SetLanguage(string language) {

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -115,7 +115,7 @@ namespace Com.OneSignal {
       public static InAppMessageAction InAppMessageActionToXam(iOS.OSInAppMessageAction inAppMessageAction) {
          return new InAppMessageAction {
             click_name = inAppMessageAction.ClickName,
-            click_url = inAppMessageAction.ClickUrl.AbsoluteString,
+            click_url = inAppMessageAction.ClickUrl?.AbsoluteString,
             closes_message = inAppMessageAction.ClosesMessage,
             first_click = inAppMessageAction.FirstClick
          };

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -52,11 +52,25 @@ namespace Com.OneSignal {
          };
       }
 
-      public static PermissionState PermissionStateToXam(iOS.OSPermissionState permissionState) {
-         return new PermissionState {
-            hasPrompted = permissionState.HasPrompted,
-            status = (NotificationPermission)permissionState.Status
+      public static DeviceState DeviceStateToXam(iOS.OSDeviceState deviceState) {
+         return new DeviceState {
+            notificationPermission = (NotificationPermission)deviceState.NotificationPermissionStatus,
+            areNotificationsEnabled = deviceState.HasNotificationPermission,
+            isSubscribed = deviceState.IsSubscribed,
+            userId = deviceState.UserId,
+            pushToken = deviceState.PushToken,
+            isPushDisabled = deviceState.IsPushDisabled,
+            isEmailSubscribed = deviceState.IsEmailSubscribed,
+            emailUserId = deviceState.EmailUserId,
+            emailAddress = deviceState.EmailAddress,
+            isSMSSubscribed = deviceState.IsSMSSubscribed,
+            smsNumber = deviceState.SmsNumber,
+            smsUserId = deviceState.SmsUserId
          };
+      }
+
+      public static NotificationPermission PermissionStateToXam(iOS.OSPermissionState permissionState) {
+         return (NotificationPermission)permissionState.Status;
       }
 
       public static PushSubscriptionState SubscriptionStateToXam(iOS.OSSubscriptionState subscriptionState) {

--- a/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
+++ b/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.props" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.props')" />
+  <Import Project="..\..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.props" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.props')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Migration.1.0.8\build\monoandroid90\Xamarin.AndroidX.Migration.props" Condition="Exists('..\..\packages\Xamarin.AndroidX.Migration.1.0.8\build\monoandroid90\Xamarin.AndroidX.Migration.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -132,53 +132,53 @@
       <HintPath>..\..\packages\Xamarin.AndroidX.Fragment.1.3.6.3\lib\monoandroid90\Xamarin.AndroidX.Fragment.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Annotations">
-      <HintPath>..\..\packages\Xamarin.Firebase.Annotations.116.0.0.2\lib\monoandroid90\Xamarin.Firebase.Annotations.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Annotations.116.0.0.3\lib\monoandroid90\Xamarin.Firebase.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="Xamarin.Firebase.Components">
-      <HintPath>..\..\packages\Xamarin.Firebase.Components.117.0.0.2\lib\monoandroid90\Xamarin.Firebase.Components.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Components.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Components.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Android.DataTransport.TransportApi">
-      <HintPath>..\..\packages\Xamarin.Google.Android.DataTransport.TransportApi.3.0.0\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportApi.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Google.Android.DataTransport.TransportApi.3.0.0.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportApi.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct">
-      <HintPath>..\..\packages\Xamarin.Google.Android.DataTransport.TransportBackendCct.3.0.0\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportBackendCct.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Google.Android.DataTransport.TransportBackendCct.3.0.0.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportBackendCct.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Android.DataTransport.TransportRuntime">
-      <HintPath>..\..\packages\Xamarin.Google.Android.DataTransport.TransportRuntime.3.0.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportRuntime.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Google.Android.DataTransport.TransportRuntime.3.0.1.1\lib\monoandroid90\Xamarin.Google.Android.DataTransport.TransportRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Basement">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.Basement.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.4\lib\monoandroid90\Xamarin.GooglePlayServices.Basement.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Measurement.Connector">
-      <HintPath>..\..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.2\lib\monoandroid90\Xamarin.Firebase.Measurement.Connector.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.3\lib\monoandroid90\Xamarin.Firebase.Measurement.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Stats">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.2\lib\monoandroid90\Xamarin.GooglePlayServices.Stats.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.3\lib\monoandroid90\Xamarin.GooglePlayServices.Stats.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Tasks">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.2\lib\monoandroid90\Xamarin.GooglePlayServices.Tasks.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.3\lib\monoandroid90\Xamarin.GooglePlayServices.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Common">
-      <HintPath>..\..\packages\Xamarin.Firebase.Common.120.0.0.2\lib\monoandroid90\Xamarin.Firebase.Common.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Common.120.0.0.3\lib\monoandroid90\Xamarin.Firebase.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Datatransport">
-      <HintPath>..\..\packages\Xamarin.Firebase.Datatransport.118.0.1.2\lib\monoandroid90\Xamarin.Firebase.Datatransport.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Datatransport.118.0.1.3\lib\monoandroid90\Xamarin.Firebase.Datatransport.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Iid.Interop">
-      <HintPath>..\..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.2\lib\monoandroid90\Xamarin.Firebase.Iid.Interop.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.3\lib\monoandroid90\Xamarin.Firebase.Iid.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Installations.InterOp">
-      <HintPath>..\..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.2\lib\monoandroid90\Xamarin.Firebase.Installations.InterOp.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Installations.InterOp.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Installations">
-      <HintPath>..\..\packages\Xamarin.Firebase.Installations.117.0.0.2\lib\monoandroid90\Xamarin.Firebase.Installations.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Installations.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Installations.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.CloudMessaging">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.2\lib\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.3\lib\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Messaging">
-      <HintPath>..\..\packages\Xamarin.Firebase.Messaging.122.0.0.2\lib\monoandroid90\Xamarin.Firebase.Messaging.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Firebase.Messaging.122.0.0.3\lib\monoandroid90\Xamarin.Firebase.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.AndroidX.CardView">
       <HintPath>..\..\packages\Xamarin.AndroidX.CardView.1.0.0.11\lib\monoandroid90\Xamarin.AndroidX.CardView.dll</HintPath>
@@ -220,7 +220,7 @@
       <HintPath>..\..\packages\Xamarin.AndroidX.Legacy.Support.V4.1.0.0.10\lib\monoandroid90\Xamarin.AndroidX.Legacy.Support.V4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Google.Guava.ListenableFuture">
-      <HintPath>..\..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.4\lib\monoandroid90\Xamarin.Google.Guava.ListenableFuture.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\lib\monoandroid90\Xamarin.Google.Guava.ListenableFuture.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.AndroidX.Concurrent.Futures">
       <HintPath>..\..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\lib\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.dll</HintPath>
@@ -265,11 +265,17 @@
       <HintPath>..\..\packages\Xamarin.AndroidX.Work.Runtime.2.7.0\lib\monoandroid90\Xamarin.AndroidX.Work.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.JavaX.Inject">
-      <HintPath>..\..\packages\Xamarin.JavaX.Inject.1.0.0\lib\monoandroid90\Xamarin.JavaX.Inject.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.JavaX.Inject.1.0.0.2\lib\monoandroid90\Xamarin.JavaX.Inject.dll</HintPath>
     </Reference>
     <Reference Include="Java.Interop" />
     <Reference Include="Xamarin.Google.Dagger">
       <HintPath>..\..\packages\Xamarin.Google.Dagger.2.39.1\lib\monoandroid90\Xamarin.Google.Dagger.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Firebase.Encoders">
+      <HintPath>..\..\packages\Xamarin.Firebase.Encoders.117.0.0.3\lib\monoandroid90\Xamarin.Firebase.Encoders.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Firebase.Encoders.JSON">
+      <HintPath>..\..\packages\Xamarin.Firebase.Encoders.JSON.118.0.0.3\lib\monoandroid90\Xamarin.Firebase.Encoders.JSON.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -320,20 +326,6 @@
   <Import Project="..\..\packages\Xamarin.Kotlin.StdLib.Jdk7.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.Jdk7.targets" Condition="Exists('..\..\packages\Xamarin.Kotlin.StdLib.Jdk7.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.Jdk7.targets')" />
   <Import Project="..\..\packages\Xamarin.Kotlin.StdLib.Jdk8.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.Jdk8.targets" Condition="Exists('..\..\packages\Xamarin.Kotlin.StdLib.Jdk8.1.5.31.2\build\monoandroid90\Xamarin.Kotlin.StdLib.Jdk8.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Migration.1.0.8\build\monoandroid90\Xamarin.AndroidX.Migration.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Migration.1.0.8\build\monoandroid90\Xamarin.AndroidX.Migration.targets')" />
-  <Import Project="..\..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Annotations.116.0.0.2\build\monoandroid90\Xamarin.Firebase.Annotations.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Annotations.116.0.0.2\build\monoandroid90\Xamarin.Firebase.Annotations.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Components.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Components.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Components.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Components.targets')" />
-  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.3\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.2\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.2\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets')" />
-  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets')" />
-  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.2\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Common.120.0.0.2\build\monoandroid90\Xamarin.Firebase.Common.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Common.120.0.0.2\build\monoandroid90\Xamarin.Firebase.Common.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Datatransport.118.0.1.2\build\monoandroid90\Xamarin.Firebase.Datatransport.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Datatransport.118.0.1.2\build\monoandroid90\Xamarin.Firebase.Datatransport.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.2\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.2\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Installations.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Installations.117.0.0.2\build\monoandroid90\Xamarin.Firebase.Installations.targets')" />
-  <Import Project="..\..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.2\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets')" />
-  <Import Project="..\..\packages\Xamarin.Firebase.Messaging.122.0.0.2\build\monoandroid90\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Messaging.122.0.0.2\build\monoandroid90\Xamarin.Firebase.Messaging.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Annotation.1.2.0.3\build\monoandroid90\Xamarin.AndroidX.Annotation.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Annotation.1.2.0.3\build\monoandroid90\Xamarin.AndroidX.Annotation.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.CardView.1.0.0.11\build\monoandroid90\Xamarin.AndroidX.CardView.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.CardView.1.0.0.11\build\monoandroid90\Xamarin.AndroidX.CardView.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Annotation.Experimental.1.1.0.3\build\monoandroid90\Xamarin.AndroidX.Annotation.Experimental.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Annotation.Experimental.1.1.0.3\build\monoandroid90\Xamarin.AndroidX.Annotation.Experimental.targets')" />
@@ -367,7 +359,6 @@
   <Import Project="..\..\packages\Xamarin.AndroidX.Fragment.1.3.6.3\build\monoandroid90\Xamarin.AndroidX.Fragment.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Fragment.1.3.6.3\build\monoandroid90\Xamarin.AndroidX.Fragment.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0.11\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0.11\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Legacy.Support.V4.1.0.0.10\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.V4.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Legacy.Support.V4.1.0.0.10\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.V4.targets')" />
-  <Import Project="..\..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.4\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets" Condition="Exists('..\..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.4\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\build\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\build\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Browser.1.3.0.8\build\monoandroid90\Xamarin.AndroidX.Browser.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Browser.1.3.0.8\build\monoandroid90\Xamarin.AndroidX.Browser.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.VectorDrawable.1.1.0.10\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.VectorDrawable.1.1.0.10\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.targets')" />
@@ -384,4 +375,21 @@
   <Import Project="..\..\packages\Xamarin.AndroidX.Work.Runtime.2.7.0\build\monoandroid90\Xamarin.AndroidX.Work.Runtime.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Work.Runtime.2.7.0\build\monoandroid90\Xamarin.AndroidX.Work.Runtime.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.MultiDex.2.0.1.10\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.MultiDex.2.0.1.10\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets')" />
   <Import Project="..\..\packages\Xamarin.AndroidX.Media.1.4.3\build\monoandroid90\Xamarin.AndroidX.Media.targets" Condition="Exists('..\..\packages\Xamarin.AndroidX.Media.1.4.3\build\monoandroid90\Xamarin.AndroidX.Media.targets')" />
+  <Import Project="..\..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.targets" Condition="Exists('..\..\packages\Xamarin.Build.Download.0.11.0\build\Xamarin.Build.Download.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Annotations.116.0.0.3\build\monoandroid90\Xamarin.Firebase.Annotations.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Annotations.116.0.0.3\build\monoandroid90\Xamarin.Firebase.Annotations.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Components.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Components.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Components.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Components.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Encoders.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Encoders.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Encoders.JSON.118.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.JSON.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Encoders.JSON.118.0.0.3\build\monoandroid90\Xamarin.Firebase.Encoders.JSON.targets')" />
+  <Import Project="..\..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets" Condition="Exists('..\..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\build\monoandroid90\Xamarin.Google.Guava.ListenableFuture.targets')" />
+  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.4\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Basement.117.6.0.4\build\monoandroid90\Xamarin.GooglePlayServices.Basement.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.3\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Measurement.Connector.119.0.0.3\build\monoandroid90\Xamarin.Firebase.Measurement.Connector.targets')" />
+  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Stats.117.0.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Stats.targets')" />
+  <Import Project="..\..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.Tasks.117.2.1.3\build\monoandroid90\Xamarin.GooglePlayServices.Tasks.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Common.120.0.0.3\build\monoandroid90\Xamarin.Firebase.Common.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Common.120.0.0.3\build\monoandroid90\Xamarin.Firebase.Common.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.3\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Iid.Interop.117.1.0.3\build\monoandroid90\Xamarin.Firebase.Iid.Interop.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Installations.InterOp.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.InterOp.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Installations.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Installations.117.0.0.3\build\monoandroid90\Xamarin.Firebase.Installations.targets')" />
+  <Import Project="..\..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets" Condition="Exists('..\..\packages\Xamarin.GooglePlayServices.CloudMessaging.117.0.0.3\build\monoandroid90\Xamarin.GooglePlayServices.CloudMessaging.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Datatransport.118.0.1.3\build\monoandroid90\Xamarin.Firebase.Datatransport.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Datatransport.118.0.1.3\build\monoandroid90\Xamarin.Firebase.Datatransport.targets')" />
+  <Import Project="..\..\packages\Xamarin.Firebase.Messaging.122.0.0.3\build\monoandroid90\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\..\packages\Xamarin.Firebase.Messaging.122.0.0.3\build\monoandroid90\Xamarin.Firebase.Messaging.targets')" />
 </Project>

--- a/Samples/Com.OneSignal.Sample.Droid/packages.config
+++ b/Samples/Com.OneSignal.Sample.Droid/packages.config
@@ -50,26 +50,28 @@
   <package id="Xamarin.AndroidX.VersionedParcelable" version="1.1.1.10" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.ViewPager" version="1.0.0.10" targetFramework="monoandroid11.0" />
   <package id="Xamarin.AndroidX.Work.Runtime" version="2.7.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Build.Download" version="0.10.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Annotations" version="116.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Common" version="120.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Components" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Datatransport" version="118.0.1.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Iid.Interop" version="117.1.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Installations" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Installations.InterOp" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Measurement.Connector" version="119.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Firebase.Messaging" version="122.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportApi" version="3.0.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportBackendCct" version="3.0.0" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Android.DataTransport.TransportRuntime" version="3.0.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Build.Download" version="0.11.0" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Annotations" version="116.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Common" version="120.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Components" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Datatransport" version="118.0.1.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Encoders" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Encoders.JSON" version="118.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Iid.Interop" version="117.1.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Installations" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Installations.InterOp" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Measurement.Connector" version="119.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Firebase.Messaging" version="122.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Android.DataTransport.TransportApi" version="3.0.0.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Android.DataTransport.TransportBackendCct" version="3.0.0.1" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Android.DataTransport.TransportRuntime" version="3.0.1.1" targetFramework="monoandroid11.0" />
   <package id="Xamarin.Google.Dagger" version="2.39.1" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.4" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="117.6.0.3" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.CloudMessaging" version="117.0.0.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Stats" version="117.0.1.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.GooglePlayServices.Tasks" version="117.2.1.2" targetFramework="monoandroid11.0" />
-  <package id="Xamarin.JavaX.Inject" version="1.0.0" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.5" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Basement" version="117.6.0.4" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.CloudMessaging" version="117.0.0.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Stats" version="117.0.1.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.GooglePlayServices.Tasks" version="117.2.1.3" targetFramework="monoandroid11.0" />
+  <package id="Xamarin.JavaX.Inject" version="1.0.0.2" targetFramework="monoandroid11.0" />
   <package id="Xamarin.Jetbrains.Annotations" version="22.0.0.2" targetFramework="monoandroid90" />
   <package id="Xamarin.Kotlin.StdLib" version="1.5.31.2" targetFramework="monoandroid90" />
   <package id="Xamarin.Kotlin.StdLib.Common" version="1.5.31.2" targetFramework="monoandroid90" />

--- a/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
+++ b/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
@@ -17,9 +17,10 @@ namespace Com.OneSignal.Sample.Shared
          OneSignal.Default.AlertLevel = LogType.NONE;
 
          OneSignal.Default.RequiresPrivacyConsent = true;
-         OneSignal.Default.PrivacyConsent = true;
 
          OneSignal.Default.Initialize("77e32082-ea27-42e3-a898-c72e141824ef");
+
+         OneSignal.Default.PrivacyConsent = true;
 
          OneSignalInAppMessagingDemo();
          OneSignalOutcomeEventDemo();

--- a/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
+++ b/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
@@ -111,4 +111,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
+  <Import Project="..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
 </Project>

--- a/Samples/OneSignalNotificationServiceExtension/packages.config
+++ b/Samples/OneSignalNotificationServiceExtension/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
+  <package id="Microsoft.NETCore.Platforms" version="6.0.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="NETStandard.Library" version="1.6.1" targetFramework="xamarinios10" />
+  <package id="NETStandard.Library" version="2.0.3" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Console" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Console" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="xamarinios10" />
@@ -19,30 +19,30 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Linq" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="xamarinios10" />
+  <package id="System.Net.Primitives" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="xamarinios10" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinios10" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
# Description

## Line Summary
Additional state getters and fixes for null reference crash on notification open for Beta 2 release of OneSignal-Xamarin-SDK 4.0.0

## Details
### Motivation
* The getters for Subscription States provide an API for users to read the device's Notificiation Permissions and Subscription states
* Notifications received could cause a null reference exception on click
* Delayed Android observers to avoid throwable thrown by initialization before `initWithContext`.

### Scope
* Add getters for Device State, Notification Permission, Push Subscription State, Email Subscription State, and SMS Subscription State. The State getters are read only and cannot be edited directly
* Xamarin Android Notification fix to null reference crashes on notification open
* Delay Android observers initialization
* Minor Cleanup and fixes

### Public API Changes
The documentation will need to be updated for Xamarin to provide these new methods.
* `DeviceState`, `NotificationPermission`, `PushSubscriptionState`, `EmailSubscriptionState` and `SMSSubscriptionState`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/267)
<!-- Reviewable:end -->
