### PR TITLE
Fix iOS nuget XCFramework nested path copy reference

### DIFF
--- a/OneSignal.iOS.Binding/Com.OneSignal.targets
+++ b/OneSignal.iOS.Binding/Com.OneSignal.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="BeforeCompile">
         <ItemGroup>
-            <BindingResources Include="$(MSBuildThisFileDirectory)../content/Com.OneSignal.iOS.resources/**/*.*" />
+            <BindingResources Include="$(MSBuildThisFileDirectory)../../content/Com.OneSignal.iOS.resources/**/*.*" />
         </ItemGroup>
         <Copy SourceFiles="@(BindingResources)" DestinationFolder="$(TargetDir)/Com.OneSignal.iOS.resources/%(RecursiveDir)" ContinueOnError="false" />
         <ItemGroup>


### PR DESCRIPTION
# Description
## One Line Summary
Fixes "OneSignal.xcframework has an incorrect or unknown format and cannot be processed" error on 4.0.0-beta1+ on iOS builds due to wrong copy path for the root `contents` folder where `OneSignal.xcframework` lives under.

## Details
Our `.nuspec` places the `OneSignal.iOS.Binding\Com.OneSignal.targets` file under `build\Xamarin.iOS10\` in the package so in order for it to access `contents` at the root it needs to go up two folder levels.
PR https://github.com/OneSignal/OneSignal-Xamarin-SDK/pull/255 where this copy command was originally added had this path wrong.

### Motivation
Fixes iOS build error reported by beta testers https://github.com/OneSignal/OneSignal-Xamarin-SDK/issues/262#issuecomment-1025663362

### Scope
Effects all iOS builds.


# Testing
## Manual testing
Tested on Visual Studio Community 2019 for Mac and locally modifying `~/.nuget/packages/com.onesignal/4.0.0-beta2/build/Xamarin.iOS10/Com.OneSignal.targets` to confirm it fixes the build and runs on an iOS 14 device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/271)
<!-- Reviewable:end -->
