### PR TITLE
Update iOS NativeConversion

### DIFF
--- a/Com.OneSignal.Core/Notification.cs
+++ b/Com.OneSignal.Core/Notification.cs
@@ -4,31 +4,43 @@ using System.Collections.Generic;
 
 namespace Com.OneSignal.Core {
    public class Notification {
-      public int androidNotificationId;
-      public List<Notification> groupedNotifications;
-      public string notificationId;
-      public string templateName;
-      public string templateId;
       public string title;
       public string body;
+      public string sound;
+      public string launchUrl;
+      public string rawPayload;
+      public List<ActionButton> actionButtons;
       public Dictionary<string, object> additionalData;
+      public string notificationId;
+      public List<Notification> groupedNotifications;
+      public BackgroundImageLayout backgroundImageLayout;
+
+      // android only
+      public string groupKey;
+      public string groupMessage;
+      public string ledColor;
+      public int priority;
       public string smallIcon;
       public string largeIcon;
       public string bigPicture;
-      public string smallIconAccentColor;
-      public string launchUrl;
-      public string sound;
-      public string ledColor;
-      public int lockScreenVisibility;
-      public string groupKey;
-      public string groupMessage;
-      public List<ActionButton> actionButtons;
-      public string fromProjectNumber;
-      public BackgroundImageLayout backgroundImageLayout;
       public string CollapseId;
-      public int priority;
-      public string rawPayload;
+      public string fromProjectNumber;
+      public string smallIconAccentColor;
+      public int lockScreenVisibility;
+      public int androidNotificationId;
+
+      //ios only
+      public string badge;
+      public string badgeIncrement;
+      public string category;
+      public string threadId;
+      public string subtitle;
+      public string templateId;
+      public string templateName;
       public float relevanceScore;
+      public bool mutableContent;
+      public bool contentAvailable;
+      public string interruptionLevel;
    }
 
    public class ActionButton {

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -46,10 +46,16 @@ namespace Com.OneSignal {
          List<ActionButton> actionButtonsXam = new List<ActionButton>();
          if(notification.ActionButtons != null) {
             foreach (NSObject actionButton in notification.ActionButtons) {
+               NSError error;
+               NSData jsonData = NSJsonSerialization.Serialize(actionButton, 0, out error);
+               NSString jsonNSString = NSString.FromData(jsonData, NSStringEncoding.UTF8);
+               string jsonString = jsonNSString.ToString();
+               Dictionary<string, string> actionButtonXam = Json.Deserialize(jsonString) as Dictionary<string, string>;
+
                actionButtonsXam.Add(new ActionButton(
-                  actionButton.ValueForKey((NSString) "id" ).ToString(),
-                  actionButton.ValueForKey((NSString) "text").ToString(),
-                  actionButton.ValueForKey((NSString) "icon").ToString()
+                  actionButtonXam.GetValueOrDefault("id"),
+                  actionButtonXam.GetValueOrDefault("text"),
+                  actionButtonXam.GetValueOrDefault("icon")
                ));
             }
          }

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -15,6 +15,16 @@ namespace Com.OneSignal {
             return Json.Deserialize(jsonString) as Dictionary<string, object>;
         }
 
+        public static Dictionary<string, string> NSObjectToPureDict(NSObject nSObject) {
+            if (nSObject == null)
+               return null;
+            NSError error;
+            NSData jsonData = NSJsonSerialization.Serialize(nSObject, 0, out error);
+            NSString jsonNSString = NSString.FromData(jsonData, NSStringEncoding.UTF8);
+            string jsonString = jsonNSString.ToString();
+            return Json.Deserialize(jsonString) as Dictionary<string, string>;
+        }
+
         public static string NSDictToString(NSDictionary nsDict) {
             if (nsDict == null)
                 return null;
@@ -46,11 +56,7 @@ namespace Com.OneSignal {
          List<ActionButton> actionButtonsXam = new List<ActionButton>();
          if(notification.ActionButtons != null) {
             foreach (NSObject actionButton in notification.ActionButtons) {
-               NSError error;
-               NSData jsonData = NSJsonSerialization.Serialize(actionButton, 0, out error);
-               NSString jsonNSString = NSString.FromData(jsonData, NSStringEncoding.UTF8);
-               string jsonString = jsonNSString.ToString();
-               Dictionary<string, string> actionButtonXam = Json.Deserialize(jsonString) as Dictionary<string, string>;
+               Dictionary<string, string> actionButtonXam = NSObjectToPureDict(actionButton);
 
                actionButtonsXam.Add(new ActionButton(
                   actionButtonXam.GetValueOrDefault("id"),

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -40,9 +40,7 @@ namespace Com.OneSignal {
       public static Notification NotificationToXam(iOS.OSNotification notification) {
          Dictionary<string, object> additionalDataXam = new Dictionary<string, object>();
          if (notification.AdditionalData != null) {
-            foreach (KeyValuePair<NSObject, NSObject> element in notification.AdditionalData) {
-               additionalDataXam.Add((NSString)element.Key, element.Value);
-            }
+            additionalDataXam = NSDictToPureDict(notification.AdditionalData);
          }
 
          List<ActionButton> actionButtonsXam = new List<ActionButton>();

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -45,6 +45,17 @@ namespace Com.OneSignal {
             }
          }
 
+         List<ActionButton> actionButtonsXam = new List<ActionButton>();
+         if(notification.ActionButtons != null) {
+            foreach (NSObject actionButton in notification.ActionButtons) {
+               actionButtonsXam.Add(new ActionButton(
+                  actionButton.ValueForKey((NSString) "id" ).ToString(),
+                  actionButton.ValueForKey((NSString) "text").ToString(),
+                  actionButton.ValueForKey((NSString) "icon").ToString()
+               ));
+            }
+         }
+
          return new Notification {
             notificationId = notification.NotificationId,
             templateName = notification.TemplateName,
@@ -56,6 +67,15 @@ namespace Com.OneSignal {
             sound = notification.Sound,
             relevanceScore = notification.RelevanceScore != null ? (float)notification.RelevanceScore : 0,
             rawPayload = notification.RawPayload.ToString(),
+            badge = notification.Badge.ToString(),
+            badgeIncrement = notification.BadgeIncrement.ToString(),
+            actionButtons = actionButtonsXam,
+            category = notification.Category,
+            threadId = notification.ThreadId,
+            subtitle = notification.Subtitle,
+            mutableContent = notification.MutableContent,
+            contentAvailable = notification.ContentAvailable,
+            interruptionLevel = notification.InterruptionLevel
          };
       }
 

--- a/Com.OneSignal.iOS/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.iOS/Utilities/NativeConversion.cs
@@ -38,16 +38,23 @@ namespace Com.OneSignal {
         }
 
       public static Notification NotificationToXam(iOS.OSNotification notification) {
+         Dictionary<string, object> additionalDataXam = new Dictionary<string, object>();
+         if (notification.AdditionalData != null) {
+            foreach (KeyValuePair<NSObject, NSObject> element in notification.AdditionalData) {
+               additionalDataXam.Add((NSString)element.Key, element.Value);
+            }
+         }
+
          return new Notification {
             notificationId = notification.NotificationId,
             templateName = notification.TemplateName,
             templateId = notification.TemplateId,
             title = notification.Title,
             body = notification.Body,
-            additionalData = Json.Deserialize(notification.AdditionalData.ToString()) as Dictionary<string, object>,
+            additionalData = additionalDataXam,
             launchUrl = notification.LaunchURL,
             sound = notification.Sound,
-            relevanceScore = (float) notification.RelevanceScore,
+            relevanceScore = notification.RelevanceScore != null ? (float)notification.RelevanceScore : 0,
             rawPayload = notification.RawPayload.ToString(),
          };
       }


### PR DESCRIPTION
# Description
## One Line Summary
Implement a fix for iOS Notification open crash

## Details
### Motivation
Fixes #274. iOS apps would crash on notification open. implementing null checks and a little more robust notification to the Xamarin method

## Test
## Manual Testing
Test on an iOS device on opening notification received

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/276)
<!-- Reviewable:end -->
