### PR TITLE
Release 4.0.0 beta4

### DIFF
--- a/Com.OneSignal.Android/Com.OneSignal.Android.csproj
+++ b/Com.OneSignal.Android/Com.OneSignal.Android.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidTlsProvider>
     </AndroidTlsProvider>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Com.OneSignal.Core/Com.OneSignal.Core.csproj
+++ b/Com.OneSignal.Core/Com.OneSignal.Core.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Com.OneSignal.iOS/Com.OneSignal.iOS.csproj
+++ b/Com.OneSignal.iOS/Com.OneSignal.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Com.OneSignal</RootNamespace>
     <AssemblyName>Com.OneSignal</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Com.OneSignal.nuspec
+++ b/Com.OneSignal.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.OneSignal</id>
-        <version>4.0.0-beta3</version>
+        <version>4.0.0-beta4</version>
         <title>OneSignal SDK for Xamarin</title>
         <authors>OneSignal, Martijn van Dijk</authors>
         <owners>OneSignal</owners>

--- a/Com.OneSignal/Com.OneSignal.csproj
+++ b/Com.OneSignal/Com.OneSignal.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -14,7 +14,7 @@
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
+++ b/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
@@ -10,7 +10,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignal.iOS.Binding</AssemblyName>
     <NoBindingEmbedding>true</NoBindingEmbedding>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.sln
+++ b/OneSignal.sln
@@ -174,6 +174,6 @@ Global
 		SolutionGuid = {DC536039-9077-48EA-BEAB-432B3B21D933}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 4.0.0-beta3
+		version = 4.0.0-beta4
 	EndGlobalSection
 EndGlobal

--- a/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
+++ b/Samples/Com.OneSignal.Sample.Droid/Com.OneSignal.Sample.Droid.csproj
@@ -17,7 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/Com.OneSignal.Sample.Shared/Com.OneSignal.Sample.Shared.csproj
+++ b/Samples/Com.OneSignal.Sample.Shared/Com.OneSignal.Sample.Shared.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
+++ b/Samples/Com.OneSignal.Sample.iOS/Com.OneSignal.Sample.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Com.OneSignal.Sample.iOS</RootNamespace>
     <AssemblyName>Com.OneSignal.Sample.iOS</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
+++ b/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>OneSignalNotificationServiceExtension</RootNamespace>
     <AssemblyName>OneSignalNotificationServiceExtension</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.0.0-beta3</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
# Description
## Line Summary
Update version numbers of OneSignal-Xamarin-SDK

## Details
### Motivation
Update OneSignal-Xamarin-SDK version numbers for release

### Scope
* Update version number of all projects and OneSignal.nuspec file for OneSignal-Xamarin-SDK to 4.0.0-beta4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/277)
<!-- Reviewable:end -->
