### PR TITLE
Xamarin method sync

### DIFF
--- a/Com.OneSignal.Android/OneSignalCallbacks.cs
+++ b/Com.OneSignal.Android/OneSignalCallbacks.cs
@@ -42,7 +42,7 @@ namespace Com.OneSignal {
          public void OnOSPermissionChanged(Android.OSPermissionStateChanges stateChanges) {
             NotificationPermission prev = NativeConversion.PermissionStateToXam(stateChanges.From.AreNotificationsEnabled());
             NotificationPermission curr = NativeConversion.PermissionStateToXam(stateChanges.To.AreNotificationsEnabled());
-            _instance.PermissionStateChanged?.Invoke(curr, prev);
+            _instance.NotificationPermissionChanged?.Invoke(curr, prev);
          }
       }
 

--- a/Com.OneSignal.Android/OneSignalCallbacks.cs
+++ b/Com.OneSignal.Android/OneSignalCallbacks.cs
@@ -94,7 +94,7 @@ namespace Com.OneSignal {
       private sealed class OSNotificationOpenedHandler : Java.Lang.Object, OneSignalNative.IOSNotificationOpenedHandler {
          public void NotificationOpened(Android.OSNotificationOpenedResult notificationOpenedResult) {
             NotificationOpenedResult result = NativeConversion.NotificationOpenedResultToXam(notificationOpenedResult);
-            _instance.NotificationWasOpened?.Invoke(result);
+            _instance.NotificationOpened?.Invoke(result);
          }
       }
 

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -153,8 +153,9 @@ namespace Com.OneSignal {
          OneSignalNative.SetLanguage(language);
       }
 
-      public override void SendTag(string key, string value) {
+      public override async Task<bool> SendTag(string key, string value) {
          OneSignalNative.SendTag(key, value);
+         return true;
       }
 
       public override async Task<bool> SendTags(Dictionary<string, object> tags) {

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -23,7 +23,7 @@ namespace Com.OneSignal {
       public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
       public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
       public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-      public override event StateChangeDelegate<NotificationPermission> PermissionStateChanged;
+      public override event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
       public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
       public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
       public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -17,7 +17,7 @@ namespace Com.OneSignal {
       public LogLevel currentAlertLevel;
 
       public override event NotificationWillShowDelegate NotificationWillShow;
-      public override event NotificationActionDelegate NotificationWasOpened;
+      public override event NotificationActionDelegate NotificationOpened;
       public override event InAppMessageLifecycleDelegate InAppMessageWillDisplay;
       public override event InAppMessageLifecycleDelegate InAppMessageDidDisplay;
       public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;

--- a/Com.OneSignal.Android/OneSignalImplementation.cs
+++ b/Com.OneSignal.Android/OneSignalImplementation.cs
@@ -13,8 +13,8 @@ using OneSignalNative = Com.OneSignal.Android.OneSignal;
 namespace Com.OneSignal {
    public partial class OneSignalImplementation : OneSignalSDK {
 
-      public LogType currentLogLevel;
-      public LogType currentAlertLevel;
+      public LogLevel currentLogLevel;
+      public LogLevel currentAlertLevel;
 
       public override event NotificationWillShowDelegate NotificationWillShow;
       public override event NotificationActionDelegate NotificationWasOpened;
@@ -58,7 +58,7 @@ namespace Com.OneSignal {
          return Task.FromResult(NotificationPermission.NotDetermined);
       }
 
-      public override LogType LogLevel {
+      public override LogLevel LogLevel {
          get => currentLogLevel;
          set {
             currentLogLevel = value;
@@ -66,7 +66,7 @@ namespace Com.OneSignal {
          }
       }
 
-      public override LogType AlertLevel {
+      public override LogLevel AlertLevel {
          get => currentAlertLevel;
          set {
             currentAlertLevel = value;

--- a/Com.OneSignal.Android/Utilities/NativeConversion.cs
+++ b/Com.OneSignal.Android/Utilities/NativeConversion.cs
@@ -142,21 +142,21 @@ namespace Com.OneSignal {
          };
       }
 
-      public static OneSignalNative.LOG_LEVEL LogConversion(LogType logLevel) {
+      public static OneSignalNative.LOG_LEVEL LogConversion(LogLevel logLevel) {
          switch (logLevel) {
-            case LogType.NONE:
+            case LogLevel.NONE:
                return OneSignalNative.LOG_LEVEL.None;
-            case LogType.FATAL:
+            case LogLevel.FATAL:
                return OneSignalNative.LOG_LEVEL.Fatal;
-            case LogType.ERROR:
+            case LogLevel.ERROR:
                return OneSignalNative.LOG_LEVEL.Error;
-            case LogType.WARN:
+            case LogLevel.WARN:
                return OneSignalNative.LOG_LEVEL.Warn;
-            case LogType.INFO:
+            case LogLevel.INFO:
                return OneSignalNative.LOG_LEVEL.Info;
-            case LogType.DEBUG:
+            case LogLevel.DEBUG:
                return OneSignalNative.LOG_LEVEL.Debug;
-            case LogType.VERBOSE:
+            case LogLevel.VERBOSE:
                return OneSignalNative.LOG_LEVEL.Debug;
             default:
                return OneSignalNative.LOG_LEVEL.None;

--- a/Com.OneSignal.Core/LogLevel.cs
+++ b/Com.OneSignal.Core/LogLevel.cs
@@ -1,0 +1,5 @@
+﻿using System;
+
+namespace Com.OneSignal.Core {
+    public enum LogLevel { NONE, FATAL, ERROR, WARN, INFO, DEBUG, VERBOSE }
+}

--- a/Com.OneSignal.Core/LogType.cs
+++ b/Com.OneSignal.Core/LogType.cs
@@ -1,5 +1,0 @@
-﻿using System;
-
-namespace Com.OneSignal.Core {
-    public enum LogType { NONE, FATAL, ERROR, WARN, INFO, DEBUG, VERBOSE }
-}

--- a/Com.OneSignal.Core/LogoutOptions.cs
+++ b/Com.OneSignal.Core/LogoutOptions.cs
@@ -1,5 +1,0 @@
-﻿using System;
-
-namespace Com.OneSignal.Core {
-    public enum LogoutOptions { Email, SMS, ExternalUserId }
-}

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -94,7 +94,7 @@ namespace Com.OneSignal.Core {
       /// <summary>
       /// When this device's permissions for authorization of push notifications have changed.
       /// </summary>
-      public abstract event StateChangeDelegate<NotificationPermission> PermissionStateChanged;
+      public abstract event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
 
       /// <summary>
       /// When this device's subscription to push notifications has changed

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -220,7 +220,7 @@ namespace Com.OneSignal.Core {
       /// Tag player with a key value pair to later create segments on them at onesignal.com
       /// </summary>
       /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
-      public abstract void SendTag(string key, string value);
+      public abstract Task<bool> SendTag(string key, string value);
 
       /// <summary>
       /// Tag player with a key value pairs to later create segments on them at onesignal.com

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -263,7 +263,7 @@ namespace Com.OneSignal.Core {
 
       /// <summary>
       /// Allows you to set the user's email address with the OneSignal SDK. If the user changes their email, you
-      /// need to call LogOut(LogOutOptions.Email) and then SetEmail to update it.
+      /// need to call LogoutEmail() and then SetEmail to update it.
       /// </summary>
       /// <param name="email">The email that you want subscribe and associate with the device</param>
       /// <param name="authHash">If you have a backend server, we strongly recommend using
@@ -274,6 +274,7 @@ namespace Com.OneSignal.Core {
 
       /// <summary>
       /// Set an sms number for the device to later send sms to this number
+      /// need to call LogoutSMS() and then SetSMSNumber to update it.
       /// </summary>
       /// <param name="smsNumber">The sms number that you want subscribe and associate with the device</param>
       /// <param name="authHash">If you have a backend server, we strongly recommend using
@@ -333,7 +334,7 @@ namespace Com.OneSignal.Core {
       /// <a href="https://documentation.onesignal.com/docs/language-localization#what-languages-are-supported">ISO 639-1</a> language codes.
       /// </summary>
       /// <param name="language"></param>
-      public abstract void SetLanguage(string language);
+      public abstract void SetLanguage(string languageCode);
 
       #region Location
       /// <summary>

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -58,7 +58,7 @@ namespace Com.OneSignal.Core {
       /// <summary>
       /// When a push notification has been opened by the user
       /// </summary>
-      public abstract event NotificationActionDelegate NotificationWasOpened;
+      public abstract event NotificationActionDelegate NotificationOpened;
 
       /*
        * In App Messages 

--- a/Com.OneSignal.Core/OneSignalSDK.cs
+++ b/Com.OneSignal.Core/OneSignalSDK.cs
@@ -117,12 +117,12 @@ namespace Com.OneSignal.Core {
       /// <summary>
       /// The minimum level of logs which will be logged to the console
       /// </summary>
-      public abstract LogType LogLevel { get; set; }
+      public abstract LogLevel LogLevel { get; set; }
 
       /// <summary>
       /// The minimum level of log events which will be converted into foreground alerts
       /// </summary>
-      public abstract LogType AlertLevel { get; set; }
+      public abstract LogLevel AlertLevel { get; set; }
 
       /// <summary>
       /// Provides privacy consent. OneSignal Xamarin SDK will not initialize until this is true.

--- a/Com.OneSignal.iOS/OneSignalCallbacks.cs
+++ b/Com.OneSignal.iOS/OneSignalCallbacks.cs
@@ -75,7 +75,7 @@ namespace Com.OneSignal {
             NotificationPermission from = NativeConversion.PermissionStateToXam(permissionStateChanges.From);
             NotificationPermission to = NativeConversion.PermissionStateToXam(permissionStateChanges.To);
 
-            _instance.PermissionStateChanged?.Invoke(to, from);
+            _instance.NotificationPermissionChanged?.Invoke(to, from);
          }
       }
 

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -14,7 +14,7 @@ namespace Com.OneSignal {
       public LogLevel currentAlertLevel;
 
       public override event NotificationWillShowDelegate NotificationWillShow;
-      public override event NotificationActionDelegate NotificationWasOpened;
+      public override event NotificationActionDelegate NotificationOpened;
       public override event InAppMessageLifecycleDelegate InAppMessageWillDisplay;
       public override event InAppMessageLifecycleDelegate InAppMessageDidDisplay;
       public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -147,8 +147,10 @@ namespace Com.OneSignal {
          return await proxy;
       }
 
-      public override void SendTag(string key, string value) {
-         OneSignalNative.SendTag(key, value);
+      public override async Task<bool> SendTag(string key, string value) {
+         BooleanCallbackProxy proxy = new BooleanCallbackProxy();
+         OneSignalNative.SendTag(key, value, response => proxy.OnResponse(true), response => proxy.OnResponse(false));
+         return await proxy;
       }
 
       public override async Task<bool> SendTags(Dictionary<string, object> tags) {

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -20,7 +20,7 @@ namespace Com.OneSignal {
       public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
       public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
       public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-      public override event StateChangeDelegate<NotificationPermission> PermissionStateChanged;
+      public override event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
       public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
       public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
       public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;

--- a/Com.OneSignal.iOS/OneSignalImplementation.cs
+++ b/Com.OneSignal.iOS/OneSignalImplementation.cs
@@ -10,8 +10,8 @@ using OneSignalNative = Com.OneSignal.iOS.OneSignal;
 
 namespace Com.OneSignal {
    public partial class OneSignalImplementation : OneSignalSDK {
-      public LogType currentLogLevel;
-      public LogType currentAlertLevel;
+      public LogLevel currentLogLevel;
+      public LogLevel currentAlertLevel;
 
       public override event NotificationWillShowDelegate NotificationWillShow;
       public override event NotificationActionDelegate NotificationWasOpened;
@@ -50,7 +50,7 @@ namespace Com.OneSignal {
          return await proxy ? NotificationPermission.Authorized : NotificationPermission.Denied;
       }
 
-      public override LogType LogLevel {
+      public override LogLevel LogLevel {
          get => currentLogLevel;
          set {
             currentLogLevel = value;
@@ -58,7 +58,7 @@ namespace Com.OneSignal {
          }
       }
 
-      public override LogType AlertLevel {
+      public override LogLevel AlertLevel {
          get => currentAlertLevel;
          set {
             currentAlertLevel = value;

--- a/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
+++ b/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
@@ -13,8 +13,8 @@ namespace Com.OneSignal.Sample.Shared
       // Called on iOS and Android to initialize OneSignal
       public static void Initialize()
       {
-         OneSignal.Default.LogLevel = LogType.VERBOSE;
-         OneSignal.Default.AlertLevel = LogType.NONE;
+         OneSignal.Default.LogLevel = LogLevel.VERBOSE;
+         OneSignal.Default.AlertLevel = LogLevel.NONE;
 
          OneSignal.Default.RequiresPrivacyConsent = true;
 

--- a/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
+++ b/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
@@ -19,6 +19,7 @@ namespace Com.OneSignal.Sample.Shared
          OneSignal.Default.RequiresPrivacyConsent = true;
 
          OneSignal.Default.Initialize("77e32082-ea27-42e3-a898-c72e141824ef");
+         OneSignal.Default.PromptForPushNotificationsWithUserResponse();
 
          OneSignal.Default.PrivacyConsent = true;
 

--- a/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
+++ b/Samples/Com.OneSignal.Sample.Shared/SharedPush.cs
@@ -25,6 +25,33 @@ namespace Com.OneSignal.Sample.Shared
 
          OneSignalInAppMessagingDemo();
          OneSignalOutcomeEventDemo();
+
+         OneSignal.Default.InAppMessageWillDisplay += _inAppMessageWillDisplay;
+         OneSignal.Default.InAppMessageDidDisplay += _inAppMessageDidDisplay;
+         OneSignal.Default.InAppMessageWillDismiss += _inAppMessageWillDismiss;
+         OneSignal.Default.InAppMessageDidDismiss += _inAppMessageDidDismiss;
+
+         OneSignal.Default.InAppMessageTriggeredAction += _inAppMessageTriggeredAction;
+      }
+
+      private static void _inAppMessageTriggeredAction(InAppMessageAction action) {
+         Console.WriteLine("In-App message Triggered Action: " + action.click_name);
+      }
+
+      private static void _inAppMessageWillDisplay(InAppMessage message) {
+         Console.WriteLine("In-App message will display: " + message.messageId);
+      }
+
+      private static void _inAppMessageDidDisplay(InAppMessage message) {
+         Console.WriteLine("In-App message did display: " + message.messageId);
+      }
+
+      private static void _inAppMessageWillDismiss(InAppMessage message) {
+         Console.WriteLine("In-App message will dismiss: " + message.messageId);
+      }
+
+      private static void _inAppMessageDidDismiss(InAppMessage message) {
+         Console.WriteLine("In-App message did dismiss: " + message.messageId);
       }
 
       private static void OneSignalSetExternalUSerId(Dictionary<string , object> results)


### PR DESCRIPTION
# Description
## One Line Summary
Sync Xamarin SDK method calls and clean up

## Details
### Motivation
Syncs Xamarin SDK method calls with the ones in Unity SDK. Clean up on certain descriptions, methods and parameter names

### Scope
* Update LogType to LogLevel
* Update PermissionStateChanged to NotificationPermissionChanged
* Update NotificationWasOpened to NotificationOpened
* Remove LogoutOptions file
* Update SetEmail and SetSMSNumber descriptions
* Update language parameter to languageCode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/278)
<!-- Reviewable:end -->
