### PR TITLE
Improve nuspec, fix compatibility with BeforeCompile and warning cleanup

### DIFF
--- a/OneSignal.iOS.Binding/OneSignalSDK.Xamarin.targets
+++ b/OneSignal.iOS.Binding/OneSignalSDK.Xamarin.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="BeforeCompile">
+    <Target Name="OneSignalAddOneSignalXCFramework" BeforeTargets="BeforeCompile">
         <ItemGroup>
             <BindingResources Include="$(MSBuildThisFileDirectory)../../content/OneSignalSDK.Xamarin.iOS.resources/**/*.*" />
         </ItemGroup>

--- a/OneSignalSDK.Xamarin.nuspec
+++ b/OneSignalSDK.Xamarin.nuspec
@@ -17,7 +17,8 @@
             <group targetFramework="netstandard2.0">
                 <dependency id="NETStandard.Library" version="2.0" />
             </group>
-            <group targetFramework="MonoAndroid">
+            <!-- Android 4.1 is the minimum version OneSignal-Android-SDK supports -->
+            <group targetFramework="MonoAndroid4.1">
                 <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.5.31.2" />
 
                 <dependency id="Xamarin.AndroidX.CardView" version="1.0.0.11" />
@@ -31,6 +32,7 @@
                      https://github.com/xamarin/XamarinComponents/issues/1069 -->
                 <dependency id="Xamarin.Google.Dagger" version="2.39.1" />
             </group>
+            <!-- OneSignal-iOS-SDK requires iOS 9.0, however Xamarin.iOS90 or Xamarin.iOS9.0 does not work. -->
             <group targetFramework="Xamarin.iOS">
                 <!-- No 3rd party iOS specific dependencies -->
                 <!-- There are Apple framework dependencies, these are defined in OneSignalSDK.Xamarin.targets -->
@@ -45,10 +47,10 @@
         <file src="OneSignalSDK.Xamarin.Core\bin\Release\netstandard2.0\OneSignalSDK.Xamarin.Core.dll" target="lib\netstandard2.0" />
 
         <!--Xamarin.Android-->
-        <file src="OneSignalSDK.Xamarin.Android\bin\Release\*OneSignal*" target="lib\MonoAndroid10" />
+        <file src="OneSignalSDK.Xamarin.Android\bin\Release\*OneSignal*" target="lib\MonoAndroid4.1" />
 
         <!--Xamarin.iOS Unified-->
-        <file src="OneSignalSDK.Xamarin.iOS\bin\Release\*OneSignal*" target="lib\Xamarin.iOS10" />
+        <file src="OneSignalSDK.Xamarin.iOS\bin\Release\*OneSignal*" target="lib\Xamarin.iOS" />
 
         <!-- Workaround to support .XCFramework for iOS  -->
         <!-- Resources includes the full OneSignal.XCFramework.
@@ -56,6 +58,6 @@
         <file src="OneSignal.iOS.Binding\bin\Release\OneSignal.iOS.Binding.resources\**" target="content\OneSignalSDK.Xamarin.iOS.resources" />
         <!-- This is a .target files that gets used by project that consumes the NuGet package.
              This copies out the OneSignal.xcframework from the resources folder and adds a NativeReference to it in the app project. -->
-        <file src="OneSignal.iOS.Binding\OneSignalSDK.Xamarin.targets" target="build\Xamarin.iOS10\" />
+        <file src="OneSignal.iOS.Binding\OneSignalSDK.Xamarin.targets" target="build\Xamarin.iOS\" />
     </files>
 </package>

--- a/OneSignalSDK.Xamarin.nuspec
+++ b/OneSignalSDK.Xamarin.nuspec
@@ -14,6 +14,9 @@
         <summary>OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your Xamarin app with OneSignal</summary>
         <tags>xamarin, monodroid, C#, OneSignal, push</tags>
         <dependencies>
+            <group targetFramework="netstandard2.0">
+                <dependency id="NETStandard.Library" version="2.0" />
+            </group>
             <group targetFramework="MonoAndroid">
                 <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.5.31.2" />
 
@@ -28,8 +31,9 @@
                      https://github.com/xamarin/XamarinComponents/issues/1069 -->
                 <dependency id="Xamarin.Google.Dagger" version="2.39.1" />
             </group>
-            <group targetFramework="netstandard2.0">
-                <dependency id="NETStandard.Library" version="2.0" />
+            <group targetFramework="Xamarin.iOS">
+                <!-- No 3rd party iOS specific dependencies -->
+                <!-- There are Apple framework dependencies, these are defined in OneSignalSDK.Xamarin.targets -->
             </group>
         </dependencies>
     </metadata>


### PR DESCRIPTION
## Details
Fix compatibility for projects with BeforeCompile
VS projects only allow you do define one target with the same name.
We give our target a unique name to prevent another target override
our BeforeCompile or us creating an issue overriding theirs.

This recommendation comes from:
https://github.com/xamarin/xamarin-macios/issues/13603#issuecomment-997730456

This PR also contains so warning fixes and other small clean up, see commit-by-commit for these details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/287)
<!-- Reviewable:end -->
