### PR TITLE
[Feature] Set Launch URLs in App

### DIFF
--- a/OneSignalSDK.Xamarin.Android/OneSignalImplementation.cs
+++ b/OneSignalSDK.Xamarin.Android/OneSignalImplementation.cs
@@ -149,6 +149,10 @@ namespace OneSignalSDK.Xamarin {
          }
       }
 
+      public override void SetLaunchURLsInApp(bool launchInApp) {
+         Console.WriteLine("OneSignal: SetLaunchURLsInApp is available on iOS only");
+      }
+
       public override void SetLanguage(string language) {
          OneSignalNative.SetLanguage(language);
       }

--- a/OneSignalSDK.Xamarin.Core/OneSignalSDKInternal.cs
+++ b/OneSignalSDK.Xamarin.Core/OneSignalSDKInternal.cs
@@ -329,6 +329,13 @@ namespace OneSignalSDK.Xamarin.Core {
       #endregion
 
       /// <summary>
+      /// Set to true to launch all notifications with a URL in the app instead of the default web browser.
+      /// iOS only method
+      /// </summary>
+      /// <param name="language"></param>
+      public abstract void SetLaunchURLsInApp(bool launchInApp);
+
+      /// <summary>
       /// Language is detected and set automatically through the OneSignal SDK based on the device settings.
       /// This method allows you to change that language by passing in the 2-character, lowercase 
       /// <a href="https://documentation.onesignal.com/docs/language-localization#what-languages-are-supported">ISO 639-1</a> language codes.

--- a/OneSignalSDK.Xamarin.iOS/OneSignalImplementation.cs
+++ b/OneSignalSDK.Xamarin.iOS/OneSignalImplementation.cs
@@ -137,6 +137,10 @@ namespace OneSignalSDK.Xamarin {
          }
       }
 
+      public override void SetLaunchURLsInApp(bool launchInApp) {
+         OneSignalNative.SetLaunchURLsInApp(launchInApp);
+      }
+
       public override void SetLanguage(string language) {
          OneSignalNative.SetLanguage(language);
       }


### PR DESCRIPTION
# Description
## One Line Summary
Add Set Launch URLs in App option

## Details
### Motivation
Set Launch URLs in App option allows a user to set the condition for a url to either open within the app or with an external browser

### Scope
* Declare SetLaunchURLsinApp in `OneSignalSDKInternal` in `OneSignalSDK.Xamarin.Core`
* Add implementation of `SetLaunchURLsinApp` in `OneSignalSDK.Xamarin.iOS`
* Add implementation of `SetLaunchURLsinApp` in `OneSignalSDK.Xamarin.Android` with a message stating `iOS only`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/288)
<!-- Reviewable:end -->
