### PR TITLE
[Update] version to 4.0.0 beta5

### DIFF
--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -14,7 +14,7 @@
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
+++ b/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
@@ -10,7 +10,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignal.iOS.Binding</AssemblyName>
     <NoBindingEmbedding>true</NoBindingEmbedding>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.sln
+++ b/OneSignal.sln
@@ -174,6 +174,6 @@ Global
 		SolutionGuid = {DC536039-9077-48EA-BEAB-432B3B21D933}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 4.0.0-beta4
+		version = 4.0.0-beta5
 	EndGlobalSection
 EndGlobal

--- a/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
+++ b/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidTlsProvider>
     </AndroidTlsProvider>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignalSDK.Xamarin.Core/OneSignalSDK.Xamarin.Core.csproj
+++ b/OneSignalSDK.Xamarin.Core/OneSignalSDK.Xamarin.Core.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/OneSignalSDK.Xamarin.iOS/OneSignalSDK.Xamarin.iOS.csproj
+++ b/OneSignalSDK.Xamarin.iOS/OneSignalSDK.Xamarin.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>OneSignalSDK.Xamarin</RootNamespace>
     <AssemblyName>OneSignalSDK.Xamarin</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignalSDK.Xamarin.nuspec
+++ b/OneSignalSDK.Xamarin.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <version>4.0.0</version>
+        <version>4.0.0-beta5</version>
         <id>OneSignalSDK.Xamarin</id>
         <title>OneSignal SDK for Xamarin</title>
         <authors>OneSignal, Martijn van Dijk</authors>

--- a/OneSignalSDK.Xamarin/OneSignalSDK.Xamarin.csproj
+++ b/OneSignalSDK.Xamarin/OneSignalSDK.Xamarin.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/OneSignalApp.Sample.Droid/OneSignalApp.Sample.Droid.csproj
+++ b/Samples/OneSignalApp.Sample.Droid/OneSignalApp.Sample.Droid.csproj
@@ -17,7 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/OneSignalApp.Sample.Shared/OneSignalApp.Sample.Shared.csproj
+++ b/Samples/OneSignalApp.Sample.Shared/OneSignalApp.Sample.Shared.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/OneSignalApp.Sample.iOS/OneSignalApp.Sample.iOS.csproj
+++ b/Samples/OneSignalApp.Sample.iOS/OneSignalApp.Sample.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>OneSignalApp.Sample.iOS</RootNamespace>
     <AssemblyName>OneSignalApp.Sample.iOS</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
+++ b/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>OneSignalNotificationServiceExtension</RootNamespace>
     <AssemblyName>OneSignalNotificationServiceExtension</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.0.0-beta4</ReleaseVersion>
+    <ReleaseVersion>4.0.0-beta5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
# Description
## Line Summary
Update version numbers of OneSignal-Xamarin-SDK

## Details
### Motivation
Update OneSignal-Xamarin-SDK version numbers for release

### Scope
* Update version number of all projects and OneSignal.nuspec file for OneSignal-Xamarin-SDK to 4.0.0-beta5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/291)
<!-- Reviewable:end -->
