### PR TITLE
[Fix] Null pointer exception on opening notification with action buttons

### DIFF
--- a/OneSignalSDK.Xamarin.iOS/Utilities/NativeConversion.cs
+++ b/OneSignalSDK.Xamarin.iOS/Utilities/NativeConversion.cs
@@ -58,12 +58,13 @@ namespace OneSignalSDK.Xamarin {
          if(notification.ActionButtons != null) {
             foreach (NSObject actionButton in notification.ActionButtons) {
                Dictionary<string, string> actionButtonXam = NSObjectToPureDict(actionButton);
-
-               actionButtonsXam.Add(new ActionButton(
-                  actionButtonXam.GetValueOrDefault("id"),
-                  actionButtonXam.GetValueOrDefault("text"),
-                  actionButtonXam.GetValueOrDefault("icon")
-               ));
+               if (actionButtonXam != null) {
+                  actionButtonsXam.Add(new ActionButton(
+                     actionButtonXam.GetValueOrDefault("id"),
+                     actionButtonXam.GetValueOrDefault("text"),
+                     actionButtonXam.GetValueOrDefault("icon")
+                  ));
+               }
             }
          }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fix null pointer exception on opening notifications with action buttons

## Details

### Motivation
Fixes bug where opening a notification with action buttons would sometimes cause a crash and throw a null pointer exception.

### Scope
* Added a null check to the dictionary parameter `actionButtonXam` in the method `NotificationToXam` is null after converting NSObject `actionButton` to dictionary

# Testing
## Manual testing
* Tested opening notifications with action buttons on iOS device

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.