### PR TITLE
Added fix for invalid cast exception for SendTags on Android

### DIFF
--- a/OneSignalSDK.Xamarin.Android/OneSignalImplementation.cs
+++ b/OneSignalSDK.Xamarin.Android/OneSignalImplementation.cs
@@ -166,7 +166,7 @@ namespace OneSignalSDK.Xamarin {
 
       public override async Task<bool> SendTags(Dictionary<string, object> tags) {
          OSChangeTagsUpdateHandler handler = new OSChangeTagsUpdateHandler();
-         OneSignalNative.SendTags((JSONObject)Json.Serialize(tags), handler);
+         OneSignalNative.SendTags(new JSONObject(Json.Serialize(tags)), handler);
          return await handler;
       }
 


### PR DESCRIPTION
# Description
## One Line Summary
Implemented a fix for the InvalidCastException noted in issue #311

## Details

### Motivation
This update was made to fix SendTags throwing and InvalidCastException whenever it is called on Android.

### Scope
This change only affects Android, and is limited to the SendTags method. I changed what was previously an attempt to cast a string to a JSONObject into using the JSONObject constructor to pass in the JSON string.

## Manual testing
I tested the code on Android 12 using Visual Studio 2022 on Windows. Calling SendTags now correctly sends the dictionary of tags passed in to the OneSignal API and the tags are visible through the web interface.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/313)
<!-- Reviewable:end -->
