### PR TITLE
[Fix] iOS builds on Windows with projects located at normal or long path lengths

### DIFF
--- a/OneSignal.iOS.Binding/OneSignalSDK.Xamarin.targets
+++ b/OneSignal.iOS.Binding/OneSignalSDK.Xamarin.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="OneSignalAddOneSignalXCFramework" BeforeTargets="BeforeCompile">
          <PropertyGroup>
-            <BindingResources>$(MSBuildThisFileDirectory)../../content/OneSignalSDK.Xamarin.iOS.resources</BindingResources>
+            <BindingResources>$(MSBuildThisFileDirectory)../../res/iOS</BindingResources>
         </PropertyGroup>
         <ItemGroup>
             <NativeReference Include="$(BindingResources)/OneSignal.xcframework">

--- a/OneSignal.iOS.Binding/OneSignalSDK.Xamarin.targets
+++ b/OneSignal.iOS.Binding/OneSignalSDK.Xamarin.targets
@@ -1,29 +1,28 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="OneSignalAddOneSignalXCFramework" BeforeTargets="BeforeCompile">
+         <PropertyGroup>
+            <BindingResources>$(MSBuildThisFileDirectory)../../content/OneSignalSDK.Xamarin.iOS.resources</BindingResources>
+        </PropertyGroup>
         <ItemGroup>
-            <BindingResources Include="$(MSBuildThisFileDirectory)../../content/OneSignalSDK.Xamarin.iOS.resources/**/*.*" />
-        </ItemGroup>
-        <Copy SourceFiles="@(BindingResources)" DestinationFolder="$(TargetDir)/OneSignalSDK.Xamarin.iOS.resources/%(RecursiveDir)" ContinueOnError="false" />
-        <ItemGroup>
-            <NativeReference Include="$(TargetDir)/OneSignalSDK.Xamarin.iOS.resources\OneSignal.xcframework">
+            <NativeReference Include="$(BindingResources)/OneSignal.xcframework">
                 <Kind>Framework</Kind>
                 <SmartLink>False</SmartLink>
                 <ForceLoad>True</ForceLoad>
                 <Frameworks>SystemConfiguration UserNotifications WebKit CoreGraphics UIKit OneSignalOutcomes OneSignalCore OneSignalExtension</Frameworks>
             </NativeReference>
-            <NativeReference Include="$(TargetDir)/OneSignalSDK.Xamarin.iOS.resources\OneSignalExtension.xcframework">
+            <NativeReference Include="$(BindingResources)/OneSignalExtension.xcframework">
                 <Kind>Framework</Kind>
                 <SmartLink>False</SmartLink>
                 <ForceLoad>True</ForceLoad>
                 <Frameworks>UserNotifications OneSignalCore OneSignalOutcomes</Frameworks>
             </NativeReference>
-            <NativeReference Include="$(TargetDir)/OneSignalSDK.Xamarin.iOS.resources\OneSignalOutcomes.xcframework">
+            <NativeReference Include="$(BindingResources)/OneSignalOutcomes.xcframework">
                 <Kind>Framework</Kind>
                 <SmartLink>False</SmartLink>
                 <ForceLoad>True</ForceLoad>
                 <Frameworks>OneSignalCore</Frameworks>
             </NativeReference>
-            <NativeReference Include="$(TargetDir)/OneSignalSDK.Xamarin.iOS.resources\OneSignalCore.xcframework">
+            <NativeReference Include="$(BindingResources)/OneSignalCore.xcframework">
                 <Kind>Framework</Kind>
                 <SmartLink>False</SmartLink>
                 <ForceLoad>True</ForceLoad>

--- a/OneSignalSDK.Xamarin.nuspec
+++ b/OneSignalSDK.Xamarin.nuspec
@@ -55,7 +55,7 @@
         <!-- Workaround to support .XCFramework for iOS  -->
         <!-- Resources includes the full OneSignal.XCFramework.
              iOS.Binding project has NoBindingEmbedding = true so it isn't also bundled in the .dll -->
-        <file src="OneSignal.iOS.Binding\bin\Release\OneSignal.iOS.Binding.resources\**" target="content\OneSignalSDK.Xamarin.iOS.resources" />
+        <file src="OneSignal.iOS.Binding\bin\Release\OneSignal.iOS.Binding.resources\**" target="res\iOS" />
         <!-- This is a .target files that gets used by project that consumes the NuGet package.
              This copies out the OneSignal.xcframework from the resources folder and adds a NativeReference to it in the app project. -->
         <file src="OneSignal.iOS.Binding\OneSignalSDK.Xamarin.targets" target="build\Xamarin.iOS\" />


### PR DESCRIPTION
# Description
## One Line Summary
Resolve most iOS builds failing on Windows due Windows due 260 character file path limits.

## Details
### Motivation
It is common for Xamarin developers to use a Windows machine and a remote macOS machine to build. Builds were failing unless your project's root was an uncommonly short path absolute path.

### Scope
Only effects iOS builds, only the linking part to `.xcframeworks`.

### Changes made
* Instead of copying the .framework files into the project from the nuget cache via the `.targets` MSBuild task instead directly reference them.
* Renamed Binding Resource files in `.target` and `.nuspec` files from `content\OneSignalSDK.Xamarin.iOS.resources` to `res\iOS` to shorten the absolute file paths

### Example of error this addresses
```
Error		Unable to copy file "C:\Users\Kasten\.nuget\packages\onesignalsdk.xamarin\4.1.0\build\Xamarin.iOS\..\..\content\OneSignalSDK.Xamarin.iOS.resources\OneSignal.xcframework\ios-arm64_armv7_armv7s\OneSignal.framework\Headers\OneSignal.h" to "C:\Users\Kasten\source\repos\XamarinFormsTest2OneSignal4_1_0\XamarinFormsTest2OneSignal4_1_0\XamarinFormsTest2OneSignal4_1_0.iOS\bin\iPhone\Debug\/OneSignalSDK.Xamarin.iOS.resources/OneSignal.xcframework\ios-arm64_armv7_armv7s\OneSignal.framework\Headers\OneSignal.h". The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.	XamarinFormsTest2OneSignal4_1_0.iOS	C:\Users\Kasten\.nuget\packages\onesignalsdk.xamarin\4.1.0\build\Xamarin.iOS\OneSignalSDK.Xamarin.targets	6	
```

### Issues this resolves
* Fixes #312
* Fixes #316
* Fixes #319 


# Testing
## Manual testing
### Window - remote mac build
* Windows 11 Pro 21H2
* Visual Studio 2022 Version 17.2.5
* Remote mac on macOS 12.3.1
* Xamarin.iOS 15.10.0.5
* Xamarin.Forms project
* Tested on both a real device and a simulator and ensured the OneSignal SDK prompts for notifications.
### Mac
* MacOS 12.4
* Visual Studio 2022 Version 17.05
* .Net 6.0.0.262
* Xamarin.iOS 15.10.0.5
* Xamarin.Forms project
* Tested on both a real device and a simulator and ensured the OneSignal SDK prompts for notifications.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/317)
<!-- Reviewable:end -->
