### PR TITLE
[Fix] Set External User Id on iOS

### DIFF
--- a/OneSignalSDK.Xamarin.Android/OneSignalImplementation.cs
+++ b/OneSignalSDK.Xamarin.Android/OneSignalImplementation.cs
@@ -86,6 +86,13 @@ namespace OneSignalSDK.Xamarin {
          return await handler;
       }
 
+      //Required as a quick fix for iOS setExternalUser non-nullable hashToken. Need removed as soon as OneSignal iOS updates hashToken to nullable
+      public override async Task<bool> SetExternalUserId(string externalId) {
+         OSExternalUserIDUpdateHandler handler = new OSExternalUserIDUpdateHandler();
+         OneSignalNative.SetExternalUserId(externalId, handler);
+         return await handler;
+      }
+
       public override async Task<bool> SetExternalUserId(string externalId, string authHash = null) {
          OSExternalUserIDUpdateHandler handler = new OSExternalUserIDUpdateHandler();
          OneSignalNative.SetExternalUserId(externalId, authHash, handler);

--- a/OneSignalSDK.Xamarin.Core/OneSignalSDKInternal.cs
+++ b/OneSignalSDK.Xamarin.Core/OneSignalSDKInternal.cs
@@ -256,6 +256,9 @@ namespace OneSignalSDK.Xamarin.Core {
 
 
       #region User & Device Properties
+      //Required as a quick fix for iOS setExternalUser non-nullable hashToken. Need removed as soon as OneSignal iOS updates hashToken to nullable
+      public abstract Task<bool> SetExternalUserId(string externalId);
+
       /// <summary>
       /// Allows you to use your own application's user id to send OneSignal messages to your user. To tie the user
       /// to a given user id, you can use this method.

--- a/OneSignalSDK.Xamarin.iOS/OneSignalImplementation.cs
+++ b/OneSignalSDK.Xamarin.iOS/OneSignalImplementation.cs
@@ -147,6 +147,13 @@ namespace OneSignalSDK.Xamarin {
          return await proxy;
       }
 
+      //Required as a quick fix for iOS setExternalUser non-nullable hashToken. Need removed as soon as OneSignal iOS updates hashToken to nullable
+      public override async Task<bool> SetExternalUserId(string externalId) {
+         BooleanCallbackProxy proxy = new BooleanCallbackProxy();
+         OneSignalNative.SetExternalUserId(externalId, response => proxy.OnResponse(true), response => proxy.OnResponse(false));
+         return await proxy;
+      }
+
       public override async Task<bool> SetExternalUserId(string externalId, string authHash = null) {
          BooleanCallbackProxy proxy = new BooleanCallbackProxy();
          OneSignalNative.SetExternalUserId(externalId, authHash, response => proxy.OnResponse(true), response => proxy.OnResponse(false));


### PR DESCRIPTION
# Description
## One Line Summary
Fix Set External User Id not working on iOS

## Details

### Motivation
Temporary fix to set external user id not working on iOS. The previous implementation uses a single `SetExternalUserId` method with optional nullable parameter `hashToken` in Xamarin. However, OneSignal iOS native SDK does not support nullable `hashToken` as a parameter. This fix uses temporary function overloading to allow users to continue using `SetExternalUserId` without a `hashToken`

### Scope
* Added `SetExternalUserId` method without `hashToken` parameter to iOS, Android and Core projects

### Issues this resolves
* Fixes #314  

# Testing
## Manual testing
* MacOS 12.4
* Visual Studio 2022 Version 17.05
* .Net 6.0.0.262
* Xamarin.iOS 15.10.0.5
* Xamarin.Forms project
* Created and tested a nuget package on an iOS device

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/318)
<!-- Reviewable:end -->
