### PR TITLE
[Release] 4.2.0-beta1-maui-only

### DIFF
--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -16,7 +16,7 @@
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
+++ b/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
@@ -14,7 +14,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignal.iOS.Binding</AssemblyName>
     <NoBindingEmbedding>true</NoBindingEmbedding>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignal.sln
+++ b/OneSignal.sln
@@ -174,6 +174,6 @@ Global
 		SolutionGuid = {DC536039-9077-48EA-BEAB-432B3B21D933}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 4.1.3
+		version = 4.2.0-beta1-maui-only
 	EndGlobalSection
 EndGlobal

--- a/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
+++ b/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
@@ -18,7 +18,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidTlsProvider>
     </AndroidTlsProvider>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -90,9 +90,6 @@
     <Reference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState">
       <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.ViewModelSavedState.2.3.1.3\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.ViewModelSavedState.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.AndroidX.Tracing.Tracing">
-      <HintPath>..\packages\Xamarin.AndroidX.Tracing.Tracing.1.0.0.3\lib\monoandroid90\Xamarin.AndroidX.Tracing.Tracing.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.AndroidX.VersionedParcelable">
       <HintPath>..\packages\Xamarin.AndroidX.VersionedParcelable.1.1.1.10\lib\monoandroid90\Xamarin.AndroidX.VersionedParcelable.dll</HintPath>
     </Reference>
@@ -131,9 +128,6 @@
     </Reference>
     <Reference Include="Xamarin.Google.Guava.ListenableFuture">
       <HintPath>..\packages\Xamarin.Google.Guava.ListenableFuture.1.0.0.5\lib\monoandroid90\Xamarin.Google.Guava.ListenableFuture.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.AndroidX.Concurrent.Futures">
-      <HintPath>..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\lib\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.AndroidX.Browser">
       <HintPath>..\packages\Xamarin.AndroidX.Browser.1.3.0.8\lib\monoandroid90\Xamarin.AndroidX.Browser.dll</HintPath>
@@ -278,6 +272,12 @@
       <HintPath>..\packages\Xamarin.Essentials.1.7.3\lib\monoandroid10.0\Xamarin.Essentials.dll</HintPath>
     </Reference>
     <Reference Include="Java.Interop" />
+    <Reference Include="Xamarin.AndroidX.Concurrent.Futures">
+      <HintPath>..\packages\Xamarin.AndroidX.Concurrent.Futures.1.1.0.5\lib\monoandroid90\Xamarin.AndroidX.Concurrent.Futures.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Tracing.Tracing">
+      <HintPath>..\packages\Xamarin.AndroidX.Tracing.Tracing.1.0.0.3\lib\monoandroid90\Xamarin.AndroidX.Tracing.Tracing.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\OneSignalSDK.Xamarin\OneSignalSDK.Xamarin.cs">
@@ -289,6 +289,10 @@
     </ProjectReference>
     <ProjectReference Include="..\OneSignalSDK.Xamarin.Core\OneSignalSDK.Xamarin.Core.csproj">
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Xamarin.AndroidX.Concurrent.Futures" />
+    <None Remove="Xamarin.AndroidX.Tracing.Tracing" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/OneSignalSDK.Xamarin.Core/OneSignalSDK.Xamarin.Core.csproj
+++ b/OneSignalSDK.Xamarin.Core/OneSignalSDK.Xamarin.Core.csproj
@@ -17,7 +17,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/OneSignalSDK.Xamarin.iOS/OneSignalSDK.Xamarin.iOS.csproj
+++ b/OneSignalSDK.Xamarin.iOS/OneSignalSDK.Xamarin.iOS.csproj
@@ -12,7 +12,7 @@
     <RootNamespace>OneSignalSDK.Xamarin</RootNamespace>
     <AssemblyName>OneSignalSDK.Xamarin</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OneSignalSDK.Xamarin.nuspec
+++ b/OneSignalSDK.Xamarin.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <version>4.1.3</version>
+        <version>4.2.0-beta1-maui-only</version>
         <id>OneSignalSDK.Xamarin</id>
         <title>OneSignal SDK for Xamarin</title>
         <authors>OneSignal</authors>

--- a/OneSignalSDK.Xamarin/OneSignalSDK.Xamarin.csproj
+++ b/OneSignalSDK.Xamarin/OneSignalSDK.Xamarin.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/OneSignalApp.Sample.Droid/OneSignalApp.Sample.Droid.csproj
+++ b/Samples/OneSignalApp.Sample.Droid/OneSignalApp.Sample.Droid.csproj
@@ -17,7 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/OneSignalApp.Sample.Shared/OneSignalApp.Sample.Shared.csproj
+++ b/Samples/OneSignalApp.Sample.Shared/OneSignalApp.Sample.Shared.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/OneSignalApp.Sample.iOS/OneSignalApp.Sample.iOS.csproj
+++ b/Samples/OneSignalApp.Sample.iOS/OneSignalApp.Sample.iOS.csproj
@@ -4,12 +4,12 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
     <ProjectGuid>{4F85DB2A-0410-44FA-A55A-54669503DBD9}</ProjectGuid>
-    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{9A19103F-16F7-4668-BE54-9A1E7A4F7556}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>OneSignalApp.Sample.iOS</RootNamespace>
     <AssemblyName>OneSignalApp.Sample.iOS</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
+++ b/Samples/OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.csproj
@@ -4,12 +4,12 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
     <ProjectGuid>{2DD024D6-B178-4229-A4D1-3E1B1B1B7390}</ProjectGuid>
-    <ProjectTypeGuids>{EE2C853D-36AF-4FDB-B1AD-8E90477E2198};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{EE2C853D-36AF-4FDB-B1AD-8E90477E2198};{9A19103F-16F7-4668-BE54-9A1E7A4F7556}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>OneSignalNotificationServiceExtension</RootNamespace>
     <AssemblyName>OneSignalNotificationServiceExtension</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>4.1.3</ReleaseVersion>
+    <ReleaseVersion>4.2.0-beta1-maui-only</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Release includes
* Support for .NET 6 MAUI projects.
* WARNING! This first 4.2.0 beta only includes .NET 6 MAUI support, does not work with .NET 5 such as Xamarin Forums.
   - Please use version 4.1.3 instead if your project is still on .NET 5.
   - Future versions add back in .NET 5 support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/328)
<!-- Reviewable:end -->
