### PR TITLE
Add StyleCop tool for lint and formatting

### DIFF
--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -46,6 +46,9 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />
     <None Include="Jars\AboutJars.txt" />
   </ItemGroup>
@@ -56,5 +59,11 @@
   </ItemGroup>
   <ItemGroup>
     <LibraryProjectZip Include="Jars\onesignal-release.aar" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   </Project>

--- a/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
+++ b/OneSignal.iOS.Binding/OneSignal.iOS.Binding.csproj
@@ -74,4 +74,13 @@
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
+++ b/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
@@ -293,9 +293,16 @@
   <ItemGroup>
     <None Remove="Xamarin.AndroidX.Concurrent.Futures" />
     <None Remove="Xamarin.AndroidX.Tracing.Tracing" />
+    <None Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets')" />
   <Import Project="..\packages\Xamarin.AndroidX.Browser.1.3.0.8\build\monoandroid90\Xamarin.AndroidX.Browser.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Browser.1.3.0.8\build\monoandroid90\Xamarin.AndroidX.Browser.targets')" />

--- a/OneSignalSDK.Xamarin.Core/OneSignalSDK.Xamarin.Core.csproj
+++ b/OneSignalSDK.Xamarin.Core/OneSignalSDK.Xamarin.Core.csproj
@@ -37,10 +37,15 @@
   <ItemGroup>
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="NETStandard.Library" />
     <None Remove="Microsoft.NETCore.Portable.Compatibility" />
+    <None Remove="StyleCop.Analyzers" />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.Xamarin.iOS/OneSignalSDK.Xamarin.iOS.csproj
+++ b/OneSignalSDK.Xamarin.iOS/OneSignalSDK.Xamarin.iOS.csproj
@@ -52,6 +52,15 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="Info.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.Xamarin/OneSignalSDK.Xamarin.csproj
+++ b/OneSignalSDK.Xamarin/OneSignalSDK.Xamarin.csproj
@@ -30,9 +30,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OneSignalSDK.Xamarin.Core\OneSignalSDK.Xamarin.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="StyleCop.Analyzers" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description
## One Line Summary
Add StyleCop tool for lint and formatting.

## Details

### Motivation
To improve code quality and readability.

### Scope
Only enables this as warnings for now.

# Testing
## Manual testing
Tested on Visual Studio 2022 for Mac (17.4 build 715), ensured new warnings show after building.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xamarin-sdk/330)
<!-- Reviewable:end -->
