### PR TITLE
Update OSGetTagsHandler to check for null tags before deserializing.

### DIFF
--- a/OneSignalSDK.Xamarin.Android/OneSignalCallbacks.cs
+++ b/OneSignalSDK.Xamarin.Android/OneSignalCallbacks.cs
@@ -147,8 +147,15 @@ namespace OneSignalSDK.Xamarin {
 
       private sealed class OSGetTagsHandler : JavaLaterProxy<Dictionary<string, object>>, OneSignalNative.IOSGetTagsHandler {
          public void TagsAvailable(JSONObject tags) {
-            var result = Json.Deserialize(tags.ToString()) as Dictionary<string, object>;
-            _later.Complete(result);
+            if (tags == null)
+            {
+               _later.Complete(null);
+            }
+            else
+            {
+               var result = Json.Deserialize(tags.ToString()) as Dictionary<string, object>;
+               _later.Complete(result);
+            }
          }
       }
 


### PR DESCRIPTION
# Description
## One Line Summary
Update OSGetTagsHandler to check for null tags before deserializing.

## Details

### Motivation
Fixes NullReferenceException when attempting `OneSignal.Default.GetTags` on a user with no tags.

### Scope
This fixes Android's implementation of GetTags within the Xamarin SDK.

# Testing

## Manual testing
Temporarily updated sample application to drive `OneSignal.Default.GetTags` and drove on Android when a user has no tags, and when a user has tags.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.