### PR TITLE
Fix link to nuget package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 ### OneSignal Xamarin SDK
-[![NuGet](https://img.shields.io/nuget/v/OneSignalSDK.Xamarin.svg?label=NuGet)](https://www.nuget.org/packages/OneSignal.Xamarin)
+[![NuGet](https://img.shields.io/nuget/v/OneSignalSDK.Xamarin.svg?label=NuGet)](https://www.nuget.org/packages/OneSignalSDK.Xamarin)
 
 ---
 


### PR DESCRIPTION
The link in the README is broken. This fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Xamarin-SDK/359)
<!-- Reviewable:end -->
