### PR TITLE
fixed NullReferenceException on Android NotificationToXam method

### DIFF
--- a/OneSignalSDK.Xamarin.Android/Utilities/NativeConversion.cs
+++ b/OneSignalSDK.Xamarin.Android/Utilities/NativeConversion.cs
@@ -34,6 +34,7 @@ namespace OneSignalSDK.Xamarin {
             nativeNotification.additionalData = Json.Deserialize(notification.AdditionalData.ToString()) as Dictionary<string, object>;
 
          if (notification.GroupedNotifications != null) {
+            nativeNotification.groupedNotifications = new List<Notification>();
             foreach (var individualNotification in notification.GroupedNotifications)
                nativeNotification.groupedNotifications.Add(NotificationToXam(individualNotification));
          }


### PR DESCRIPTION
# Description
## One Line Summary
Fix for a NullReferenceException on Android when opening a notification. The issue is in the `NativeConversion.NotificationToXam(OneSignalAndroid.OSNotification notification)` method.


### Motivation
Fixes a crash when getting a notification after getting several crash reports on a production app.

```
NativeConversion.NotificationToXam (Com.OneSignal.Android.OSNotification notification)
System.NullReferenceException: Object reference not set to an instance of an object
NativeConversion.NotificationToXam (Com.OneSignal.Android.OSNotification notification)
NativeConversion.NotificationOpenedResultToXam (Com.OneSignal.Android.OSNotificationOpenedResult result)
OneSignalImplementation+OSNotificationOpenedHandler.NotificationOpened (Com.OneSignal.Android.OSNotificationOpenedResult notificationOpenedResult)
OneSignal+IOSNotificationOpenedHandlerInvoker.n_NotificationOpened_Lcom_onesignal_OSNotificationOpenedResult_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_p0)
JNINativeWrapper.Wrap_JniMarshal_PPL_V (_JniMarshal_PPL_V callback, System.IntPtr jnienv, System.IntPtr klazz, System.IntPtr p0)

```


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Xamarin-SDK/361)
<!-- Reviewable:end -->
